### PR TITLE
按照我的想法稍微完善了一下，请黄同学有空时看看 :-)

### DIFF
--- a/data/pinyin-utf8.dat
+++ b/data/pinyin-utf8.dat
@@ -1,0 +1,25359 @@
+㐀 qiu1
+㐁 tian3 tian4
+㐄 kua4
+㐅 wu3
+㐆 yin3
+㐌 si4 yi2
+㐖 ye4
+㐜 chou2
+㐡 nuo4
+㐤 qiu2
+㐨 xu4
+㐩 xing2
+㐫 xiong1
+㐬 liu2
+㐭 lin3
+㐮 xiang1
+㐯 yong1
+㐰 xin4
+㐱 zhen3
+㐲 dai4
+㐳 wu4
+㐴 pan1
+㐷 ma3 ma4 mian2
+㐸 qian4
+㐹 yi4
+㐺 zhong4
+㐻 n3 nei4 ng3
+㐼 cheng4 zheng3
+㑁 zhuo1
+㑂 fang3 pang2
+㑃 ao3
+㑄 wu3
+㑅 zuo4
+㑇 zhou4
+㑈 dong4
+㑉 su4
+㑊 yi4
+㑋 jiong4 kong3 qiong2
+㑌 wang1 kuang1
+㑍 lei3 lei4
+㑎 nao3
+㑏 zhu4
+㑔 xu3
+㑘 jie4
+㑙 die2 yong3
+㑚 nuo2
+㑛 su4
+㑜 yi4
+㑝 long4
+㑞 ying4
+㑟 beng3 bo2 peng3
+㑣 lan2
+㑤 miao2
+㑥 yi4
+㑦 li4
+㑧 ji4
+㑨 yu3
+㑩 luo2
+㑪 chai2
+㑮 hun2
+㑯 xu3
+㑰 hui4
+㑱 rao3
+㑳 zhou4
+㑵 han4 ji2 jie2 zha3 zi2
+㑶 xi4
+㑷 tai4 tian4 zhuan4
+㑸 ai3 yao2 you2
+㑹 hui4
+㑺 jun4
+㑻 ma4
+㑼 lve4
+㑽 tang2
+㑾 xiao2 yao2
+㑿 tiao2 zhao4
+㒀 zha3
+㒁 yu3 yun4
+㒂 ku4 zhuo2
+㒃 er4
+㒄 nang4 nen4 ran3
+㒅 qi3
+㒆 chi4 ke4 xi4 xiao4 yan4
+㒇 mu4 wu3
+㒈 han4
+㒉 tang3
+㒊 se4
+㒌 qiong2
+㒍 lei2 lei3
+㒎 sa3 sa4 tan4
+㒑 hui4 kui3
+㒒 pu2
+㒓 ta4
+㒔 shu3
+㒖 ou3
+㒗 tai2
+㒙 mian2
+㒚 wen3
+㒛 diao4
+㒜 yu2 yu3
+㒝 mie4 wa4
+㒞 jun4 ke3
+㒟 niao3
+㒠 xie4
+㒡 you2
+㒤 she4
+㒦 lei3
+㒧 li4
+㒩 luo3
+㒫 ji4
+㒰 quan2
+㒲 cai2
+㒳 liang3
+㒴 gu3
+㒵 mao4
+㒷 gua3 xing4 xu3
+㒸 sui4 xuan2
+㒻 mao4
+㒼 man2
+㒾 shi4
+㒿 li2 li4
+㓁 wang3
+㓂 kou4
+㓃 chui2 du4 zha4
+㓄 zhen4
+㓈 bing4 bei4 fei4 ye4
+㓉 huan4 huo2 huo4
+㓊 dong4
+㓋 gong4
+㓎 lian2 qin3 qin4
+㓏 jiong3
+㓐 lu4
+㓑 xing4
+㓓 nan2
+㓔 xie4
+㓖 bi4 bie2
+㓗 jie2 qi3
+㓘 su4
+㓜 you4
+㓝 xing2
+㓞 qi4 qia4 yao2
+㓠 dian4
+㓡 fu3
+㓢 luo4
+㓣 qia4
+㓤 jie2 qia4
+㓧 yan3
+㓨 ci2 ci4
+㓪 lang3
+㓭 he2
+㓯 li2
+㓰 hua4
+㓱 tou2
+㓲 pian4
+㓴 jun4 ruan3
+㓵 e4
+㓶 qie4
+㓷 yi4
+㓸 jue2 zhuo2
+㓹 rui4
+㓺 jian4
+㓼 chi4 chong4
+㓽 chong2
+㓾 chi2
+㔀 lve4 qing2
+㔂 lin2
+㔃 jue2 pi4
+㔄 su4
+㔅 xiao4
+㔆 chan2
+㔉 zhu2
+㔊 dan3
+㔋 jian4 lan2 lan4
+㔌 zhou4
+㔍 duo3 zha2
+㔎 xie4 yi4
+㔏 li4
+㔑 chi4 dao4 qi4 shui4
+㔒 xi2
+㔓 jian3 xian4
+㔕 ji2 yi4
+㔗 fei4
+㔘 chu4
+㔙 bang3 peng2
+㔚 kou3
+㔜 ba2 bo2
+㔝 liang3
+㔞 kuai4 kuang4 wang4
+㔠 he2 jia2
+㔢 jue2
+㔣 lei2 lei4
+㔤 shen3
+㔥 pi2
+㔦 yang3
+㔧 lv4 xue4
+㔨 bei4
+㔩 e4
+㔪 lu3
+㔭 che4 chi2 yi2
+㔮 nuo2
+㔯 suan3 xuan2
+㔰 heng2
+㔱 yu3
+㔳 gui3 gun4 huan2 jue2
+㔴 yi4
+㔵 xian4 xuan3
+㔶 gong4
+㔷 lou4
+㔹 le4
+㔺 shi4
+㔼 sun3
+㔽 yao4 you3
+㔾 jie2
+㔿 zou4
+㕁 que4
+㕂 yin2
+㕄 zhi4
+㕅 jia3
+㕆 hu4
+㕇 la2
+㕈 hou4 yi3
+㕉 ke4
+㕋 jing4 qin2
+㕌 ai4
+㕎 e4 ke4 kun3
+㕏 chu2
+㕐 xie3
+㕑 chu2
+㕒 wei2 wei3
+㕕 huan4
+㕖 su4
+㕗 you4
+㕙 jun4 rui4
+㕚 zhao3
+㕛 xu4 you3 you4
+㕜 shi3
+㕟 kui4
+㕡 he2 he4 huo4
+㕢 gai4 hai4 ju4 lun3 nou3
+㕣 yan3 yan4
+㕤 qiu2
+㕥 yi3
+㕦 hua4
+㕨 fan4
+㕩 zhang4
+㕪 dan3
+㕫 fang3
+㕬 song4
+㕭 ao4 bi4
+㕮 fu3 tiao4
+㕯 nei4
+㕰 he4
+㕱 you2
+㕲 hua2 ying2
+㕴 chen2
+㕵 guo2 hun2 luo3
+㕶 ng4
+㕷 hua4
+㕸 li4
+㕹 fa2
+㕺 hao2
+㕻 pou3 tou4
+㕽 si4
+㖀 le4 luo4
+㖁 lin4
+㖂 yi4
+㖃 hou3
+㖅 xu4
+㖆 qu2 qu3
+㖇 er2
+㖏 nei4
+㖐 wei3
+㖑 xie4
+㖒 ti2
+㖓 hong2
+㖔 tun3
+㖕 bo4 nie4
+㖖 nie4
+㖗 yin2
+㖞 wai1
+㖟 shou4
+㖠 ba4 nuo4
+㖡 ye4
+㖢 ji2 qi2
+㖣 tou4
+㖤 han2
+㖥 jiong3
+㖦 dong3
+㖧 wen3
+㖨 lu4
+㖩 sou3
+㖪 guo2
+㖫 ling2
+㖭 tian3
+㖮 lun2
+㖶 ye4
+㖷 shi2 ti2
+㖸 xue2
+㖹 fen4
+㖺 chun3
+㖻 rou2
+㖼 duo3 lin2 mou2
+㖽 ze2 zei2
+㖾 e4
+㖿 xie2
+㗁 e4
+㗂 sheng3
+㗃 wen3 yin4
+㗄 man2 man4
+㗅 hu2
+㗆 ge2 kai4
+㗇 xia2
+㗈 man4
+㗉 bi4 e4 lve4
+㗊 ji2
+㗋 hou2
+㗌 zhi4
+㗑 bai4
+㗒 ai4
+㗕 gou4
+㗖 dan4
+㗗 bai3
+㗘 bo2 fu4
+㗙 na4
+㗚 li4
+㗛 xiao4
+㗜 xiu4
+㗢 dong4
+㗣 ti4
+㗤 cu4
+㗥 kuo4
+㗦 lao2
+㗧 zhi4
+㗨 ai3
+㗩 xi1
+㗫 qie4
+㗰 chu4 cong2
+㗱 ji2
+㗲 huo4 xi4
+㗳 ta3
+㗴 yan2
+㗵 xu4
+㗷 sai3
+㗼 ye4
+㗽 xiang3
+㗿 xia4
+㘀 zuo4
+㘁 yi4
+㘂 ci2
+㘅 xian2
+㘆 tai2
+㘇 rong2
+㘈 yi1
+㘉 zhi4
+㘊 yi4
+㘋 xian2
+㘌 ju4
+㘍 ji2 qi4
+㘎 han3 han4
+㘐 pao4 peng3
+㘑 li4
+㘓 lan2
+㘔 can3 sai3
+㘕 han3 lan2
+㘖 yan2
+㘙 yan2 yan3
+㘚 han3
+㘜 chi3 chou2 chu4
+㘝 nian3 nie4
+㘞 huo4
+㘠 bi4 mi4
+㘡 xia2
+㘢 weng3
+㘣 xuan2 yuan2
+㘥 you2
+㘦 qin2
+㘧 xu4
+㘨 nei4
+㘩 bi4
+㘪 hao4
+㘫 jing3
+㘬 ao4
+㘭 ao4
+㘲 ju2
+㘴 zuo4
+㘵 bu4
+㘶 jie2
+㘷 ai4
+㘸 zang4
+㘹 ci2
+㘺 fa2
+㘿 nie4
+㙀 liu4
+㙁 mang3 mei2 mei4 mu4 na4
+㙂 dui4
+㙄 bi4
+㙅 bao3
+㙇 chu4
+㙈 han2 xia4
+㙉 tian3
+㙊 chang2 zhang4
+㙏 fu4
+㙐 duo3
+㙑 yu3
+㙒 ye3
+㙓 kui2
+㙔 han2
+㙕 kuai4
+㙗 kuai4
+㙙 long3
+㙛 bu3
+㙜 chi2 tai2
+㙝 xie2
+㙞 nie4
+㙟 lang3
+㙠 yi4
+㙢 man2 men2
+㙣 zhang4
+㙤 xia4
+㙥 gun3
+㙨 ji4 qi2
+㙩 liao2
+㙪 ye4 yi4
+㙫 ji2
+㙬 yin2
+㙮 da1 da5
+㙯 yi4
+㙰 xie4
+㙱 hao4
+㙲 yong3
+㙳 han3 he2 kan3
+㙴 chan4 zhan4
+㙵 tai2
+㙶 tang2
+㙷 zhi2
+㙸 bao4 bo2 pu2
+㙹 meng2
+㙺 gui4 kui2
+㙻 chan2 qie4 zan4
+㙼 lei3
+㙾 xi4 xue2
+㚁 qiao2 qiao4 qu4
+㚂 rang2
+㚃 yun2 yun4
+㚅 long2
+㚆 fu4
+㚉 gu3
+㚌 hua4 huo3
+㚍 guo2 kui3 kui4
+㚏 gao3
+㚐 tao4
+㚒 shan3
+㚓 lai2 lai3
+㚔 nie4
+㚕 fu2
+㚖 gao3
+㚗 qie2 xie2
+㚘 ban4
+㚛 xi4
+㚜 xu4 yu4
+㚝 kui2
+㚞 meng3 shen3 ying4 yun4
+㚟 chuo4
+㚡 ji3
+㚢 nu2
+㚣 xiao2
+㚤 yi4
+㚥 yu2
+㚦 yi2
+㚧 yan3
+㚩 ran3
+㚪 hao4
+㚫 sha4 zha4
+㚭 you2
+㚯 xin2 xun2
+㚰 bi3
+㚲 dian3 shan4
+㚴 bu4
+㚶 si4
+㚷 er3 nai3
+㚹 mao3
+㚺 yun4
+㚽 qiao3
+㚿 pao2
+㛂 nuo3
+㛃 jie2
+㛅 er4
+㛆 duo3
+㛊 duo3
+㛍 qie4
+㛏 ou4 qiu2
+㛐 sou3 xuan2
+㛑 can4
+㛒 dou4
+㛔 peng2
+㛕 yi4
+㛗 zuo4
+㛘 po4
+㛙 qie4 qin2 shen3 shen4
+㛚 tong3
+㛛 xin4 zhen4
+㛜 you2
+㛝 bei4 beng4
+㛞 long4
+㛥 ta4
+㛦 lan3
+㛧 man3
+㛨 qiang3
+㛩 zhou2
+㛪 yan4 yuan2
+㛬 lu4
+㛮 sao3
+㛯 mian3
+㛱 rui4 wei3
+㛲 fa4
+㛳 cha4 yi4
+㛴 nao3
+㛶 chou2 tan2 tan4
+㛸 shu4
+㛹 pian2
+㛻 kui3
+㛼 sha4
+㛾 xian2
+㛿 zhi4
+㜃 lian4 liao2 mang2
+㜄 xun2
+㜅 xu4
+㜆 mi4
+㜇 hui4 ye4
+㜈 mu4
+㜊 pang4 zhan3
+㜋 yi4
+㜌 gou4
+㜍 tang2
+㜎 qi2 xi4
+㜏 yun2
+㜐 shu4
+㜑 fu2 po2
+㜒 yi4
+㜓 da2
+㜕 lian2
+㜖 cao2
+㜗 can3 chu2 xuan4
+㜘 ju4
+㜙 lu4
+㜚 su4
+㜛 nen4 ruan3
+㜜 ao4
+㜝 an3 an4
+㜞 qian4
+㜣 ran2
+㜤 shen3
+㜥 mai2 mo2
+㜦 han4 nie4 si4 xie2 xin2
+㜧 yue4
+㜨 er2 nai2
+㜩 ao4 bie2
+㜪 xian3
+㜫 ma4 mei2 mei3
+㜮 lan4
+㜰 yue4
+㜱 dong4 zhi4
+㜲 weng3 ying2
+㜳 huai2
+㜴 meng4
+㜵 niao3
+㜶 wan3
+㜷 mi2 nai3 xian3
+㜸 nie4
+㜹 qu2
+㜺 zan4
+㜻 lian4
+㜼 zhi2 zhi4
+㜽 zi3
+㜾 hai2
+㜿 xu4
+㝀 hao4
+㝁 xun2
+㝂 zhi4
+㝃 fan4 mian3 wan3
+㝄 chun2 qi4 run4
+㝅 gou4
+㝇 chun2
+㝈 luan2
+㝉 zhu4
+㝊 shou3
+㝋 liao2 liao3 liu2
+㝌 jie2 jiu4 zhou4
+㝍 xie3
+㝎 ding4
+㝏 jie4
+㝐 rong2
+㝑 mang2 pang2
+㝓 ge2 ke4
+㝔 yao4
+㝕 ning2
+㝖 yi2 yin2
+㝗 lang2
+㝘 yong2
+㝙 yin2
+㝛 su4
+㝝 lin2
+㝞 ya4
+㝟 mao2 mao4 wu3
+㝠 ming2
+㝡 zui4
+㝢 yu3
+㝣 ye4 yi4
+㝤 gou4
+㝥 mi3
+㝦 jun4 ya2
+㝧 wen3
+㝪 dian4 ding3
+㝫 long2
+㝭 xing3
+㝮 cui4
+㝯 qiao2
+㝰 mian2
+㝱 meng4
+㝲 qin3
+㝴 wan2
+㝵 de2 ai4
+㝶 ai4 de2
+㝸 bian4
+㝹 nou2
+㝺 lian2 lin2
+㝻 jin3
+㝽 chui2 shui3 zhui3
+㝾 zuo3
+㝿 bo2 bo3 fu4 qian4
+㞁 yao4
+㞂 tui3
+㞃 ji2
+㞅 guo3
+㞆 ji3
+㞇 wei3
+㞊 xu4
+㞋 nian3
+㞌 yun4
+㞎 ba3 fu2 pa2
+㞏 zhe2
+㞐 ju1
+㞑 wei3
+㞒 xi4 xie4
+㞓 qi3 qi4
+㞔 yi2
+㞕 xie4
+㞖 ci4
+㞗 qiu2
+㞘 tun2
+㞙 niao4
+㞚 qi4 zha3
+㞛 ji3
+㞟 dian4
+㞠 lao2 liao2
+㞡 zhan3
+㞤 yin2
+㞥 cen2
+㞦 ji3
+㞧 hui4
+㞨 zai3 zi3
+㞩 lan2
+㞪 nao2
+㞫 ju4 zou3
+㞬 qin4
+㞭 dai4
+㞯 jie2
+㞰 xu3
+㞲 yong4
+㞳 dou3
+㞴 chi2
+㞶 min3
+㞷 huang2
+㞸 sui4
+㞹 ke3
+㞺 zu2
+㞻 hao4
+㞼 cheng2 sheng4 zhe2
+㞽 xue4
+㞾 ni2 yi4
+㞿 chi4 qi2
+㟀 lian2
+㟁 an4
+㟂 chi3 mu3
+㟄 xiang2
+㟅 yang2
+㟆 hua2
+㟇 cuo2 cuo3
+㟈 qiu2
+㟉 lao2
+㟊 fu2
+㟋 dui4
+㟌 mang2
+㟍 lang2
+㟎 tuo3
+㟏 han2
+㟐 mang3
+㟑 bo2
+㟓 qi2
+㟔 han2
+㟖 long4
+㟘 tiao2
+㟙 lao3 ze2 zhai2
+㟚 qi2
+㟛 zan4
+㟜 mi2
+㟝 pei2 pou3
+㟞 zhan4
+㟟 xiang4
+㟠 gang3
+㟢 qi2
+㟤 lu4
+㟦 yun4
+㟧 e4 nie4 xun4
+㟨 quan2
+㟩 min2 min3 wen3
+㟪 wei3
+㟫 quan2
+㟬 shu3 sou3
+㟭 min2
+㟰 ming3
+㟱 yao3
+㟲 jue2 yuan2
+㟳 li4
+㟴 kuai4 kui3 wei3
+㟵 gang3
+㟶 yuan2
+㟷 da5
+㟹 lao2
+㟺 lou2
+㟻 qian4
+㟼 ao2
+㟽 biao3
+㟿 mang2 mang3
+㠀 dao3
+㠂 ao2
+㠄 xi2
+㠅 fu2 fu4
+㠇 jiu4
+㠈 run4
+㠉 tong2
+㠊 qu1
+㠋 e4
+㠍 ji2 jie2 qi4
+㠎 ji2 qi4
+㠏 hua2
+㠐 jiao4
+㠑 zui4
+㠒 biao3
+㠓 meng2
+㠔 bai4
+㠕 wei3
+㠖 ji4 yi3
+㠗 ao4 wo4
+㠘 yu3
+㠙 hao2
+㠚 dui4 zhuo2
+㠛 wo4
+㠜 ni4
+㠝 cuan2
+㠟 li2
+㠠 lu2
+㠡 niao3
+㠢 hua4 huai2 huan4 mo4
+㠣 lai4 li4
+㠥 lv4
+㠧 mi2 mi3
+㠨 yu4
+㠪 ju4
+㠭 zhan3 zhan4
+㠯 yi3
+㠱 ji4 qi3
+㠲 bi3
+㠴 ren4
+㠶 fan2
+㠷 ge2
+㠸 ku4
+㠹 jie4
+㠺 miao2
+㠽 tong2
+㠿 ci3
+㡀 bi4
+㡁 kai3 kua4
+㡂 li4
+㡄 sun3 xun2
+㡅 nuo3
+㡇 ji2 zhe2
+㡈 men2 wen4
+㡉 xian2 yan2
+㡊 qia4 qian3
+㡋 e4 ye2
+㡌 mao4 mei4
+㡏 tou2
+㡑 qiao3
+㡔 wu4
+㡖 chuang2
+㡗 ti2
+㡘 lian2
+㡙 bi4 pi2
+㡛 mang2
+㡜 xue3
+㡝 feng4 fu2
+㡞 lei3 lou2 lv3
+㡠 zheng4
+㡡 chu2
+㡢 man4
+㡣 long2
+㡥 yin3
+㡧 zheng4
+㡨 qian1
+㡩 luan2
+㡪 nie2
+㡫 yi4
+㡭 ji4 kui2
+㡮 ji2
+㡯 zhai2
+㡰 yu3
+㡱 jiu3
+㡲 huan2
+㡳 di3 zhe2 zhi3
+㡵 ling2
+㡶 ji4 zhi3
+㡷 ben3
+㡸 zha3 zha4
+㡹 ci4
+㡺 dan4
+㡻 liao4
+㡼 yi4
+㡽 zhao4
+㡾 xian4
+㡿 chi4
+㢀 ci4 zi4
+㢁 chi3
+㢂 yan3
+㢃 lang2
+㢄 dou4
+㢅 long4
+㢆 chan2
+㢈 tui2
+㢉 cha2
+㢊 ai3
+㢋 chi3
+㢍 ying2 ying3
+㢎 cha4 ze2 zhai2 zhe2
+㢏 tou2
+㢑 tui2
+㢒 cha2
+㢓 yao3 zhang4
+㢔 zong3
+㢗 qiao4
+㢘 lian2
+㢙 qin2
+㢚 lu3
+㢛 yan4
+㢞 yi4
+㢟 chan3
+㢠 jiong3 jun4
+㢡 jiang3
+㢣 jing4 qing2
+㢥 dong4
+㢧 juan4
+㢨 han4
+㢩 di4
+㢬 hong2
+㢮 chi2
+㢯 min2
+㢰 bi4 huan2
+㢲 xun4
+㢳 lu2 lv4
+㢵 she4 xie2
+㢶 bi4
+㢸 bi4
+㢺 xian2
+㢻 wei3
+㢼 bie4
+㢽 er3
+㢾 juan4
+㣀 zhen4
+㣁 bei4
+㣂 yi4
+㣃 yu3 yu4
+㣄 qu2
+㣅 zan4
+㣆 mi2 pei4
+㣇 ni3 yi4
+㣈 si4
+㣌 shan4
+㣍 tai2
+㣎 mu4
+㣏 jing4
+㣐 bian4
+㣑 rong2
+㣒 ceng4
+㣓 can4
+㣙 di2
+㣚 tong2 tong3
+㣛 ta4
+㣜 xing2
+㣞 duo2 duo4
+㣟 xi4
+㣠 tong2
+㣢 ti2
+㣣 shan3 shan4
+㣤 jian4
+㣥 zhi4
+㣧 yin4 yong3
+㣪 huan3 kuo4
+㣫 zhong3
+㣬 qi4
+㣯 xie4
+㣰 xie4
+㣱 ze2 zuo4
+㣲 wei2
+㣵 ta4
+㣶 zhan1
+㣷 ning4
+㣻 yi4
+㣼 ren3
+㣽 shu4
+㣾 cha4
+㣿 zhuo2
+㤁 mian3 tian3
+㤂 ji2
+㤃 fang2
+㤄 pei4
+㤅 ai4
+㤆 fan4
+㤇 ao3 fo2 wu4
+㤈 qin4
+㤉 qia4 ya2
+㤊 xiao4 yao2
+㤍 qiao3
+㤏 tong2
+㤑 you4
+㤓 ben4
+㤔 fu2 fu4
+㤕 chu4
+㤖 zhu4
+㤘 chu4 cu4 zhou4
+㤚 hang2
+㤛 nin2 ren4
+㤜 jue2 yu4
+㤞 cha4
+㤟 kong3 tou4
+㤠 lie4
+㤡 li4
+㤢 xu4 yu4
+㤤 yu2 yu3
+㤥 hai4
+㤦 li4
+㤧 hou2 hou4
+㤨 gong3 qiong2
+㤩 ke4
+㤪 yuan4
+㤫 de2
+㤬 hui4 kui4
+㤮 kuang2
+㤯 jiong3 jun4
+㤰 zan3 zuo4
+㤱 fu4
+㤲 qie4 qu4
+㤳 bei3
+㤴 xi2
+㤵 ci2
+㤶 pang2
+㤸 xi4
+㤹 qiu2
+㤺 huang3
+㤽 chou2
+㤾 san4
+㥀 de2
+㥁 de2 zhi2 zhou4
+㥂 te4
+㥃 men4
+㥄 ling2
+㥅 shou4
+㥆 dian4 tui4
+㥇 can2 can4
+㥈 die2
+㥉 che4 chi4
+㥊 peng2
+㥌 ju2
+㥍 ji4
+㥎 lai2 li2
+㥏 tian3
+㥐 yuan4
+㥒 cai3
+㥓 qi3
+㥔 yu2 yu4
+㥕 lian2
+㥚 yu2
+㥛 ji2 ke4 su4
+㥜 wei4
+㥝 mi3 mian3
+㥞 cui4 qian4 sui4
+㥟 xie2
+㥠 xu3
+㥡 xi4
+㥢 qiu2
+㥣 hui4
+㥥 yu2
+㥦 qie4 xia2 xian3
+㥧 shun4
+㥨 chui2 shui4 wei3
+㥩 duo3
+㥪 lou2
+㥬 pang2
+㥭 tai4
+㥮 zhou4
+㥯 yin3
+㥱 fei3
+㥲 shen4 yin2
+㥳 yuan2
+㥴 yi2
+㥵 hun4
+㥶 se4
+㥷 ye4 yi4
+㥸 min3
+㥹 fen3
+㥺 he2 he4
+㥼 yin3
+㥽 ce4 ze2
+㥾 ni4
+㥿 ao4
+㦀 feng2
+㦁 lian2
+㦂 chang2 tang4
+㦃 chan3
+㦄 ma2 mi4
+㦅 di4
+㦇 lu4
+㦉 yi4
+㦊 hua2
+㦌 tui4 xu4
+㦍 e4
+㦎 hua4
+㦏 sun3 xuan4
+㦐 ni4
+㦑 lian3 xian4
+㦒 li2
+㦓 xian4
+㦔 yan4
+㦕 long2
+㦖 men4
+㦗 jian4 jin4
+㦚 bian3
+㦛 yu2 yu3
+㦜 huo4 xue4
+㦝 miao3
+㦞 chou2
+㦟 hai4 mai2
+㦡 le4
+㦢 jie2 qi4
+㦣 wei4
+㦤 yi4
+㦥 huan2 xian3
+㦦 he4
+㦧 can3
+㦨 lan2 lan4
+㦩 yin3
+㦪 xie4
+㦬 luo3
+㦭 ling2
+㦮 qian2
+㦯 huo4
+㦱 wo3
+㦴 ge2 qia4
+㦶 die2
+㦷 yong3
+㦸 ji3
+㦹 ang4 yang2 ying3
+㦺 ru3 ru4
+㦻 xi2 zhe2
+㦼 shuang4
+㦽 xu4 yu4
+㦾 yi2
+㦿 hu4
+㧀 ji2
+㧁 qu4
+㧂 tian2
+㧄 qian3 qiu2
+㧅 mu4
+㧇 mao3
+㧈 yin3 yin4
+㧉 gai4 kui4
+㧊 ba2
+㧋 xian3 xuan3
+㧌 mao4
+㧍 fang3
+㧎 ya2
+㧐 song3
+㧑 wei2 wei3
+㧒 xue2 yu4 yue4
+㧔 guai4
+㧕 jiu4 liu3 yu2
+㧖 e4
+㧗 zi3
+㧘 cui4 nao3 zi4
+㧙 bi4
+㧚 wa3
+㧜 lie4
+㧟 kuai3
+㧡 hai4
+㧣 zhu4
+㧤 chong4
+㧥 xian3
+㧦 xuan4
+㧨 qiu2
+㧩 pei4
+㧪 gui3
+㧫 er2
+㧬 gong3
+㧭 qiong2
+㧯 lao3
+㧰 li4
+㧱 chen4 na2 ni4 tian4
+㧲 san3
+㧳 bo2 zhuo4
+㧴 wo3
+㧵 pou2 pou3
+㧷 duo4 tun4
+㧹 te4
+㧺 ta4
+㧻 zhi3 zhuo2 zu2
+㧼 biao4
+㧽 gu4 hu2
+㨀 bing3
+㨁 zhi2 zhi4
+㨂 dong3
+㨃 cheng2 dui3
+㨄 zhao4
+㨅 nei4 rui4
+㨆 lin3
+㨇 po2
+㨈 ji3
+㨉 min3
+㨊 wei3
+㨋 che3 le4 zhen4
+㨌 gou4 ru2 ru3
+㨎 ru2 ruan2
+㨐 bu3 pei2
+㨒 kui2 wei3 xie2
+㨓 lao2 liao2
+㨔 han4
+㨕 ying2
+㨖 zhi4
+㨗 jie2
+㨘 xing3
+㨙 xie2
+㨚 xun2
+㨛 shan3
+㨜 qian2
+㨝 xie4
+㨞 su4
+㨟 hai2
+㨠 mi4
+㨡 hun2
+㨤 hui4 kuai3 wai4
+㨥 na4
+㨦 song3
+㨧 ben4
+㨨 liu4
+㨩 jie2
+㨪 huang4
+㨫 lan3
+㨭 hu4
+㨮 dou1
+㨯 huo4 kuo4
+㨰 ge2 gun3 hun4 huo4 jie2
+㨱 yao2
+㨲 ce4
+㨳 gui3
+㨴 jian4
+㨵 jian3
+㨶 chou2 dao3 zhou3 zhou4
+㨷 jin4
+㨸 ma4
+㨹 hui4
+㨺 men2 mi4 mian3
+㨻 can2
+㨼 lve4
+㨽 pi3 pi4 qiao3
+㨾 yang4
+㨿 ju4
+㩀 ju4
+㩁 que4
+㩄 shai1
+㩆 jiu4
+㩇 hua4 huo4
+㩈 xian4 yun3
+㩉 xie2
+㩋 su4
+㩌 fei4
+㩍 ce4
+㩎 ye4
+㩒 qin2
+㩓 hui3
+㩔 tun2
+㩖 qiang2 tiao2
+㩗 xi2 xie2
+㩘 yi3
+㩚 meng2
+㩛 tuan2
+㩜 lan3
+㩝 hao2
+㩞 ci4
+㩟 zhai4
+㩠 piao3
+㩡 luo3
+㩢 mi2 mie4
+㩦 xie2
+㩧 bo2
+㩨 hui4
+㩩 qi3 qing3
+㩪 xie2 xin4 ye2
+㩭 bo2 jiao3 xiao4
+㩮 qian2 xian2
+㩯 ban3 pan2 po2
+㩰 jiao3 qiao2 xiu3
+㩱 jue2
+㩲 kun3 quan2
+㩳 song3
+㩴 ju2
+㩵 e4
+㩶 nie4 ning3
+㩸 die2
+㩹 die2 zha2
+㩻 gui3
+㩽 qi2
+㩾 chui2
+㪀 yu2
+㪁 qin2
+㪃 ke3 ke4
+㪄 fu2
+㪆 di3
+㪇 xian4
+㪈 gui4
+㪉 he2
+㪊 qun2
+㪋 han4
+㪌 tong3 yu2 yu3
+㪍 bo2
+㪎 shan3
+㪏 bi3
+㪐 lu4
+㪑 ye4
+㪒 ni2
+㪓 chuai2
+㪔 san4 tan2
+㪕 diao4
+㪖 lu4
+㪗 tou3
+㪘 lian3
+㪙 ke3 ke4 kuo4
+㪚 san4
+㪛 zhen3
+㪜 chuai3
+㪝 lian4
+㪞 mao4
+㪠 qian4
+㪡 ke3
+㪢 shao3
+㪣 qiao4
+㪤 bi4
+㪦 yin4
+㪨 shan4
+㪩 su4
+㪪 sa4 xi3
+㪫 rui4
+㪬 zhuo2
+㪭 lu2
+㪮 ling2
+㪯 cha2 ju3 qu2
+㪱 huan4
+㪴 jia2
+㪵 ban4
+㪶 hu2
+㪷 dou3
+㪹 lou3 lu4
+㪻 juan4
+㪼 ke3
+㪽 suo3 suo4
+㪾 ge2 luo4
+㪿 zhe2
+㫀 ding3
+㫁 duan4
+㫂 zhu4
+㫃 yan3
+㫄 pang2
+㫅 cha2 qi2 shi2
+㫊 yi3
+㫍 you2
+㫎 gun3 kuai4
+㫏 yao3
+㫐 yao3
+㫑 shi2 zhi3
+㫒 gong3
+㫓 qi3 qi4
+㫔 gen4
+㫗 hou4
+㫘 mi4 mian3
+㫙 fu2
+㫚 hu1
+㫛 guang4 kuang2 kuang4 mu3
+㫜 dan4 tan3
+㫟 yan2
+㫢 qu4
+㫤 chang3 zhao4
+㫥 ming3
+㫧 bao4
+㫫 xian3
+㫯 mao4
+㫰 lang3
+㫱 nan3
+㫲 pei4
+㫳 chen2
+㫶 cou3 zhou3
+㫸 qie4
+㫹 dai4 shu4 yu2
+㫻 kun4
+㫼 die2 zhe2 zhi4
+㫽 lu4
+㬂 yu2
+㬃 tai2
+㬄 chan4
+㬅 man4
+㬆 mian2 mian4 min3
+㬇 huan4
+㬉 nuan3 ruo4
+㬊 huan3
+㬋 hou2
+㬌 jing4
+㬍 bo2
+㬎 xian3
+㬏 li4
+㬐 jin3 jin4 xing2 ying3
+㬒 mang3 mao4
+㬓 piao4
+㬔 hao2
+㬕 yang2
+㬗 xian4
+㬘 su4
+㬙 wei3
+㬚 che4
+㬜 jin4
+㬝 ceng2
+㬞 he4
+㬠 shai4
+㬡 ling2
+㬣 dui4
+㬥 pu4
+㬦 yue4
+㬧 bo2
+㬩 hui4
+㬪 die2 zhi4
+㬫 yan4
+㬬 ju4
+㬭 jiao4 shan3 yao3
+㬮 kuai4 nan4
+㬯 lie4
+㬰 yu2
+㬱 ti4
+㬳 wu3
+㬴 hong3
+㬵 xiao2
+㬶 hao4
+㬻 huang3
+㬼 fu4
+㬿 dun4
+㭁 reng2
+㭂 jiao3
+㭄 xin4
+㭇 yuan4
+㭈 jue2 kuai4
+㭉 hua2
+㭋 bang4
+㭌 mou2 yu2
+㭏 wei3
+㭑 mei4
+㭒 si4
+㭓 bian4
+㭔 lu2
+㭘 he2
+㭙 she2 zhe2
+㭚 lv3
+㭛 pai4
+㭜 rong2
+㭝 qiu2
+㭞 lie4
+㭟 gong3
+㭠 xian3
+㭡 xi4 xin4
+㭤 niao3
+㭨 xie2 ye2
+㭩 lei4 ling2
+㭫 cuan2 cuo2 zhen4
+㭬 zhuo2
+㭭 fei4
+㭮 zuo4
+㭯 die2 na4 zhe2
+㭰 ji4 jue2 zui3
+㭱 he2 xia2
+㭲 ji2
+㭸 tu2
+㭹 xian2
+㭺 yan3
+㭻 tang2
+㭼 ta4
+㭽 di3
+㭾 jue2 yue4
+㭿 ang2
+㮀 han2
+㮁 yao2
+㮂 ju2
+㮃 rui2
+㮄 bang3 bi4 peng2
+㮆 nie4
+㮇 tian4
+㮈 nai4
+㮋 you3 yu4
+㮌 mian2 min3
+㮏 nai4
+㮐 xing3
+㮑 qi4
+㮓 gen4
+㮔 tong2
+㮕 er2 ruan3
+㮖 jia2
+㮗 qin2
+㮘 mao4
+㮙 e4
+㮚 li4
+㮛 chi2
+㮝 he2 luo4
+㮞 jie2 ni2 ya2
+㮟 ji2 nian3 nv4 peng4 rou4
+㮡 guan4
+㮢 hou2
+㮣 gai4 ze2
+㮥 fen4
+㮦 se4 suo3
+㮨 ji2 ji4
+㮪 qiong2
+㮫 he2
+㮭 xian2
+㮮 jie2
+㮯 hua2 hun2 kuan3
+㮰 bi2 pi2
+㮳 zhen4
+㮶 shi4 shuo4
+㮸 song4
+㮹 zhi3
+㮺 ben3
+㮾 lang3
+㮿 bi4
+㯀 xian3 xuan4
+㯁 bang4
+㯂 dai4
+㯅 pi2
+㯆 chan3
+㯇 bi4
+㯈 su4
+㯉 huo4
+㯊 hen2
+㯋 ying3
+㯌 chuan2
+㯍 jiang3
+㯎 nen4
+㯏 gu3
+㯐 fang3 tuo3
+㯓 ta4
+㯔 cui4
+㯖 de2
+㯗 ran3 shun4 xian2 xian4
+㯘 kuan3
+㯙 che4
+㯚 da2
+㯛 hu2 huo4
+㯜 cui4
+㯝 lu4
+㯞 juan4 yue4
+㯟 lu4
+㯠 qian4 xian4 xun2
+㯡 pao4
+㯢 zhen4
+㯤 li4
+㯥 cao2 zha2
+㯦 qi2
+㯩 ti4
+㯪 ling2
+㯫 qu2
+㯬 lian3
+㯭 lu3
+㯮 shu3
+㯯 gong4
+㯰 zhe2 zhi2
+㯱 biao3 piao2
+㯲 jin4
+㯳 qing2
+㯶 zong1
+㯷 pu2
+㯸 jin3
+㯹 biao3
+㯺 jian4
+㯻 gun3 hun4
+㯿 lie4
+㰀 li2
+㰁 luo3
+㰂 shen3 sun3
+㰃 mian2
+㰄 jian4
+㰅 di2
+㰆 bei4
+㰈 lian3
+㰊 xun2
+㰋 pin2
+㰌 que4
+㰍 long2
+㰎 zui4
+㰐 jue2 kui2 lei3 tui3 tuo3
+㰒 she2 xue2
+㰔 xie4
+㰖 lan3
+㰗 cu4
+㰘 yi2
+㰙 nuo2
+㰚 li2
+㰛 yue4
+㰝 yi3
+㰟 ji4
+㰠 kang4
+㰡 xie4
+㰣 zi4
+㰤 ke3 qia4
+㰥 hui4
+㰦 qu4
+㰪 wa2
+㰬 xun2
+㰮 shen4
+㰯 kou4
+㰰 qie4
+㰱 sha4
+㰲 xu4 yu4
+㰳 ya4
+㰴 po2 pou3
+㰵 zu2
+㰶 you3
+㰷 zi4
+㰸 lian3 lian4 luan3
+㰹 jin4
+㰺 xia2
+㰻 yi3
+㰼 qie4
+㰽 mi3 yan4
+㰾 jiao4
+㱀 chi3 chuai4
+㱁 shi4
+㱃 yin3
+㱄 mo4
+㱅 yi4
+㱇 se4
+㱈 jin4
+㱉 ye4
+㱋 que4
+㱌 che4 yan3 ye2
+㱍 luan2
+㱏 zheng4
+㱖 cui4
+㱘 an4 yan3
+㱙 xiu3
+㱚 can2 hai4 shan4
+㱛 chuan3
+㱜 zha2
+㱞 ji2
+㱟 bo2 pi2 pi3
+㱢 lang2
+㱣 tui3
+㱥 ling2
+㱦 e4 gui4 ji3
+㱧 wo4
+㱨 lian4
+㱩 du2
+㱪 men4
+㱫 lan4
+㱬 wei3
+㱭 duan4
+㱮 kuai4 kui4
+㱯 ai2 bei4 ji4 jian4 shan3 shen4 yi3
+㱰 zai3
+㱱 hui4 wu4 xi4
+㱲 yi4
+㱳 mo4
+㱴 zi4
+㱵 ben4 fen4
+㱶 beng4 jiao4 peng2 qiao3 ru4
+㱸 bi4 bie2
+㱹 li4 suan4 xian4
+㱺 lu2
+㱻 luo3
+㱽 dan4 qin2
+㱿 que4
+㲀 chen2
+㲂 cheng2
+㲃 jiu4
+㲄 kou4
+㲅 ji4
+㲆 ling2
+㲈 shao2
+㲉 kai4 ke2
+㲊 rui4
+㲋 chuo4 zhuo2 zu2
+㲌 neng4
+㲎 lou2
+㲏 bao3 piao3 pin2 ping4
+㲒 bao4
+㲓 rong2
+㲕 lei4
+㲘 qu2
+㲛 zhi3
+㲜 tan2 tan3
+㲝 rong3
+㲞 zu2
+㲟 ying3
+㲠 mao2
+㲡 nai4 ni4
+㲢 bian4 bie2
+㲥 tang2
+㲦 han4 he3
+㲧 zao4
+㲨 rong2
+㲫 pu2
+㲭 tan3
+㲯 ran2
+㲰 ning2
+㲱 lie4
+㲲 die2 yi4
+㲳 die2
+㲴 zhong4 zhou4
+㲶 lv4
+㲷 dan4
+㲹 gui3 qiu2
+㲺 ji2 ke4 lei2
+㲻 ni4
+㲼 yi4
+㲽 nian4 ren3 xian4
+㲾 yu3 yu4
+㲿 wang3
+㳀 guo4 kai3 xi4
+㳁 ze4
+㳂 yan2
+㳃 cui4
+㳄 xian2
+㳅 jiao3 liu2
+㳆 shu3 tou3
+㳇 fu4
+㳈 pei4
+㳍 bu4
+㳎 bian4 fan4
+㳏 chi3 shi4
+㳐 sa4 zha2 zha3
+㳑 yi4
+㳒 bian4 fa3
+㳔 dui4
+㳕 lan2
+㳗 chai4
+㳙 xuan4
+㳚 yu4
+㳛 yu2
+㳠 ta4
+㳥 ju4 long4
+㳦 xie4
+㳧 xi2
+㳨 jian3 za2 zan3
+㳪 pan4 pi4
+㳫 ta4
+㳬 xuan2
+㳭 xian2
+㳮 niao4
+㳴 mi4
+㳵 ji4
+㳶 gou4
+㳷 wen3
+㳹 wang3
+㳺 you2
+㳻 ze2
+㳼 bi4
+㳽 mi3
+㳿 xie4
+㴀 fan4
+㴁 yi4
+㴃 lei4 li4
+㴄 ying2
+㴆 jin4 xing4
+㴇 she4
+㴈 yin4
+㴉 ji3
+㴋 su4
+㴏 wang3
+㴐 mian4
+㴑 su4
+㴒 yi4
+㴓 zai3
+㴔 se4 yi4
+㴕 ji2
+㴖 luo4
+㴘 mao4
+㴙 zha2
+㴚 sui4
+㴛 zhi4
+㴜 bian4
+㴝 li2
+㴥 qiao4
+㴦 guan4
+㴨 zhen4
+㴪 nie4
+㴫 jun4
+㴬 xie4
+㴭 yao3
+㴮 xie4
+㴰 neng2
+㴳 long3
+㴴 chen2
+㴵 mi4
+㴶 que4
+㴸 na4 shan3 ye4
+㴼 su4
+㴽 xie4 yin4
+㴾 bo2
+㴿 ding3
+㵀 cuan4 zu2
+㵂 chuang3 shu4
+㵃 che4 mang2 she2 tan2 tuo4 zui4
+㵄 han4 qia4 yu4
+㵅 dan4 tan4
+㵆 hao4
+㵊 shen3 zhe2
+㵋 mi4
+㵌 chan4 qiong2 xun2
+㵍 men4
+㵎 han3 jian4 kan3
+㵏 cui3
+㵐 jue2
+㵑 he4
+㵒 fei4
+㵓 shi2
+㵔 che3 che4
+㵕 shen4
+㵖 nv4
+㵗 fu4 pan2 ping2
+㵘 man4
+㵝 yi4
+㵞 chou2
+㵡 bao2
+㵢 lei2 lei3
+㵣 ke3 luo3
+㵤 dian4 sha4 xia2
+㵥 bi4 mi4
+㵦 sui2
+㵧 ge2
+㵨 bi4 pi4
+㵩 yi4
+㵪 xian2
+㵫 ni3 yi4
+㵬 ying2
+㵭 zhu3
+㵮 chun2 wen3
+㵯 feng2
+㵰 xu4
+㵱 piao3
+㵲 wu3
+㵳 liao2 liu2
+㵴 cang2
+㵵 zou4
+㵷 bian4
+㵸 yao4 yue4
+㵹 huan2
+㵺 pai2 pai4
+㵻 sou4
+㵽 dui4 lei3
+㵾 jing4 qing4
+㵿 xi2
+㶁 guo2
+㶄 yan2
+㶅 xue2
+㶆 chu2
+㶇 heng2
+㶈 ying2 ying4
+㶌 lian2
+㶍 xian3
+㶎 huan2
+㶑 lian4
+㶒 shan3 shen3 tan4
+㶓 cang2
+㶔 bei4
+㶕 jian3
+㶖 shu4
+㶗 fan4
+㶘 dian4
+㶚 ba4
+㶛 yu2
+㶞 nang3
+㶟 lei3
+㶠 yi4
+㶡 dai4 huo3 zuo2
+㶣 chan2
+㶤 chao3
+㶦 jin4
+㶧 nen4
+㶫 liao3 liao4
+㶬 mei2 mo4
+㶭 jiu4 you3
+㶯 liu4
+㶰 han2
+㶲 yong4
+㶳 jin4
+㶴 chi3 shi3
+㶵 ren4
+㶶 nong2
+㶹 hong4
+㶺 tian4
+㶿 bo2
+㷀 qiong2
+㷂 shu4
+㷃 cui3
+㷄 hui4
+㷅 chao3 miao3
+㷆 dou4 fu4
+㷇 guai4 kui2
+㷈 e4
+㷉 wei4 yu4 yun4
+㷊 fen2
+㷋 tan2 tan3
+㷍 lun2
+㷎 he4 hong2 xie2
+㷏 yong3
+㷐 hui3
+㷒 yu2
+㷓 zong3
+㷔 yan4
+㷕 qiu2
+㷖 zhao4
+㷗 jiong3
+㷘 tai2
+㷟 tui4
+㷠 lin2
+㷡 jiong3
+㷢 zha3
+㷤 he4 hu4 xue4
+㷦 xu4
+㷪 cui4 zuan3
+㷫 qing3
+㷬 mo4
+㷯 beng4
+㷰 li2
+㷳 yan4
+㷴 ge2 li4
+㷵 mo4
+㷶 bei4 bi4
+㷷 juan3
+㷸 die2 ye4
+㷹 shao4
+㷻 wu2
+㷼 yan4
+㷾 jue2
+㸀 tai2
+㸁 han3 han4
+㸃 dian3
+㸄 ji4 jie2
+㸅 jie2
+㸉 xie4
+㸊 la4 lai4 lie4
+㸋 fan2
+㸌 huo4
+㸍 xi4
+㸎 nie4
+㸏 mi2
+㸐 ran2
+㸑 cuan4
+㸒 yin2
+㸓 mi4
+㸕 jue2
+㸗 tong2
+㸘 wan4
+㸚 li3
+㸛 shao2 shuo4
+㸜 kong4
+㸝 kan3
+㸞 ban3
+㸠 tiao3
+㸢 bei4
+㸣 ye4 yi4
+㸤 pian4
+㸥 chan2
+㸦 hu4
+㸧 ken4 yin2
+㸩 an4
+㸪 chun2
+㸫 qian2
+㸬 bei4 fei4 pei4
+㸮 fen2
+㸰 tuo2
+㸱 tuo2
+㸲 zuo2 zuo4
+㸳 ling2
+㸵 gui3 wei3
+㸷 shi4
+㸸 hou3 ou3
+㸹 lie4
+㸻 si4
+㸽 bei4
+㸾 ren4
+㸿 du2
+㹀 bo2
+㹁 liang2
+㹂 ci4 qian3
+㹃 bi4 fei4
+㹄 ji4 qi4
+㹅 zong3
+㹇 he2
+㹈 li2 mao2
+㹉 yuan2
+㹊 yue4
+㹌 chan3 sheng4
+㹍 di2 du2
+㹎 lei2
+㹏 jin3
+㹐 chong2 zhou4
+㹑 si4 yi2
+㹒 pu3
+㹓 yi4
+㹖 huan4
+㹗 tao2
+㹘 ru2 ru4 rui2
+㹙 ying2
+㹚 ying2
+㹛 rao2
+㹜 yin2
+㹝 shi4
+㹞 yin2 yin3
+㹟 jue2
+㹠 tun2
+㹡 xuan2 xuan4
+㹤 qie4 que4
+㹥 zhu4
+㹨 you4
+㹫 xi4 yi2
+㹬 shi3
+㹭 yi4
+㹮 mo4
+㹱 hu2 que4 ran3
+㹲 xiao4
+㹳 wu2
+㹵 jing4
+㹶 ting2
+㹷 shi3 xin4
+㹸 ni2
+㹺 ta4
+㹼 chu3 ju2 yu4
+㹽 chan3 shan4
+㹾 piao3
+㹿 diao3 zhao4 zhuo2
+㺀 nao2
+㺁 nao3
+㺂 gan3 jian4 yan2
+㺃 gou3
+㺄 yu3
+㺅 hou2
+㺉 hu4
+㺊 yang4
+㺌 xian4
+㺎 rong2
+㺏 lou2
+㺐 zhao3
+㺑 can2
+㺒 liao4 yao2
+㺓 piao4
+㺔 hai4 wei4
+㺕 fan2
+㺖 han3
+㺗 dan4 yan2
+㺘 zhan4
+㺚 ta3
+㺛 zhu4
+㺜 ban3 nong2 wan4
+㺝 jian4
+㺞 yu2
+㺟 zhuo2
+㺠 you4 yu4
+㺡 li4
+㺥 chan2 tan2
+㺦 lian2
+㺩 jiu4 se4
+㺪 pu2
+㺫 qiu2
+㺬 gong3
+㺭 zi3
+㺮 yu2
+㺱 reng2
+㺲 niu3
+㺳 mei2
+㺵 jiu2
+㺷 xu4
+㺸 ping2
+㺹 bian4
+㺺 mao4
+㺿 yi2
+㻀 you2 yu2
+㻂 ping2
+㻄 bao3
+㻅 hui4 kuai4
+㻉 bu4
+㻊 mang2 men2 meng4
+㻋 la4 lei4
+㻌 tu2
+㻍 wu2
+㻎 li4 se4
+㻏 ling2 ling3
+㻑 ji4
+㻒 jun4
+㻔 duo3 rui4
+㻕 jue2
+㻖 dai4
+㻗 bei4
+㻝 la4
+㻞 bian4 fen4 pin4
+㻟 sui2
+㻠 tu2
+㻡 die2 jue2
+㻧 duo4 he2
+㻪 sui4
+㻫 bi4
+㻬 tu2
+㻭 se4 ze2
+㻮 can4
+㻯 tu2
+㻰 mian3 re4 wei4 yu4
+㻲 lv3
+㻵 zhan4
+㻶 bi3 bi4
+㻷 ji2
+㻸 cen2 jin4 xin2
+㻺 li4 lie4
+㻽 sui4
+㻿 shu3
+㼂 e2 wen4 yuan3
+㼇 qiong2
+㼈 luo2
+㼉 yin4 zhen4
+㼊 tun2
+㼋 gu3 jiu3 mou2 ru3
+㼌 yu3
+㼍 lei3
+㼎 bei4 bo2 ke3
+㼏 nei3
+㼐 pian2
+㼑 lian4 luan2
+㼒 qiu3 tang3
+㼓 lian2 lian3
+㼖 li4
+㼗 ding3 ting2
+㼘 wa3
+㼙 zhou4
+㼛 xing2
+㼜 ang4 pou2
+㼝 fan4 wan3
+㼞 peng4
+㼟 bai2
+㼠 tuo2
+㼢 e3 yi2
+㼣 bai3 bo2
+㼤 qi4 qie4 ya4
+㼥 chu2 kao3 tou3
+㼦 gong3
+㼧 tong2
+㼨 han2
+㼩 cheng2
+㼪 jia2
+㼫 huan4
+㼬 xing4
+㼭 dian4 niao3
+㼮 mai2
+㼯 dong4
+㼰 e2 pi2
+㼱 ruan3
+㼲 lie4
+㼳 sheng3
+㼴 ou3
+㼵 di4
+㼶 yu2
+㼷 chuan2
+㼸 rong2
+㼺 tang2
+㼻 cong2
+㼼 piao2
+㼽 shuang3
+㼾 lu4
+㼿 tong2
+㽀 zheng4
+㽁 li4
+㽂 sa4
+㽇 guai4 hu2 hui2 meng2 se4
+㽈 yi4
+㽉 han3 jian4 xian4
+㽊 xie4
+㽋 luo2 luo4
+㽌 liu4
+㽎 dan3 tan2
+㽑 tan2
+㽕 you2
+㽖 nan2
+㽘 gang3
+㽙 jun4
+㽚 chi4
+㽛 kou4 qu2
+㽜 wan3
+㽝 li4
+㽞 liu2
+㽟 lie4
+㽠 xia2
+㽢 an3 ye4
+㽣 yu4
+㽤 ju2
+㽥 rou2
+㽦 xun2
+㽨 cuo2
+㽩 can4 cao4
+㽪 zeng3 zha3
+㽫 yong3
+㽬 fu4
+㽭 ruan3
+㽯 xi2
+㽰 shu4
+㽱 jiao3
+㽲 jiao3
+㽳 han4 xie4 xu3 yu2
+㽴 zhang4
+㽷 shui4
+㽸 chen2
+㽹 fan4 wan3
+㽺 ji2
+㽽 gu4
+㽾 wu4
+㾀 qie4
+㾁 shu4
+㾃 tuo2
+㾄 du2
+㾅 si4 zhi4 zi3
+㾆 ran2 shan3
+㾇 mu4
+㾈 fu4
+㾉 ling2
+㾊 ji2
+㾋 xiu4
+㾌 xuan3
+㾍 nai2
+㾏 jie4
+㾐 li4
+㾑 da2
+㾒 ji4 ru2 ru4
+㾔 lv3
+㾕 shen3
+㾖 li3 luo2
+㾗 lang3 liang4
+㾘 geng3
+㾙 yin3
+㾛 qin3
+㾜 qie4
+㾝 che4
+㾞 you3
+㾟 bu4
+㾠 huang2 kuang2 kui4
+㾡 que4
+㾢 lai4
+㾥 xu4
+㾦 bang4 pei4 pen2
+㾧 ke4
+㾨 qi3 yi3
+㾪 sheng3
+㾭 zhou4
+㾮 huang2
+㾯 tui2 wei3
+㾰 hu2
+㾱 bei4 fan4 fei4 fu2
+㾵 ji4
+㾶 gu3
+㾸 gao3
+㾹 chai2
+㾺 ma4 mo4
+㾻 zhu4
+㾼 tui3
+㾽 tui2 zhui4
+㾾 lian2
+㾿 lang2 lang3
+㿃 dai4 zhi4
+㿄 ai4
+㿅 xian3 xuan3
+㿇 xi2 xi4
+㿉 tui2
+㿊 can3
+㿋 sao4
+㿍 jie4
+㿎 fen4
+㿏 qun2
+㿑 yao4
+㿒 dao3
+㿓 jia2
+㿔 lei3
+㿕 yan2
+㿖 lu2
+㿗 tui2
+㿘 ying2
+㿙 pi4
+㿚 luo4
+㿛 li2 li4
+㿜 bie3
+㿞 mao4
+㿟 bai2 jiao3
+㿢 yao4 zhui4
+㿣 he2 xia2
+㿤 chun3
+㿥 hu2
+㿦 ning4
+㿧 chou2
+㿨 li4
+㿩 tang3
+㿪 huan2
+㿫 bi4
+㿭 che4
+㿮 yang4
+㿯 da2
+㿰 ao2
+㿱 xue2
+㿵 ran3
+㿷 zao4
+㿸 wan3
+㿹 ta4
+㿺 bao2
+㿼 yan2
+㿾 zhu4
+㿿 ya3
+䀀 fan2
+䀁 you4
+䀃 tui2
+䀄 meng2
+䀅 she4 zhe2
+䀆 jin4
+䀇 gu3 que4
+䀈 qi4
+䀉 qiao2 sha4
+䀊 jiao3
+䀋 yan2
+䀍 kan4
+䀎 mian3
+䀏 xian4
+䀐 san3
+䀑 na4 ni4 wo4
+䀓 huan4
+䀔 niu2 ren4
+䀕 cheng4 zhen4
+䀗 jue2
+䀘 xi2 xie2
+䀙 qi4
+䀚 ang2
+䀛 mei4 wu4
+䀜 gu3 mei4 xue2
+䀟 fan2 fei4 fen4
+䀠 qu2
+䀡 chan4 tan4
+䀢 shun4
+䀣 bi4 mi4
+䀤 mao4
+䀥 shuo4
+䀦 gu3
+䀧 hong3
+䀨 huan4
+䀩 luo4
+䀪 hang2
+䀫 jia2
+䀬 quan2
+䀮 mang2
+䀯 bu3
+䀰 gu3 ying2
+䀲 mu4
+䀳 ai4 la4 lai4
+䀴 ying3
+䀵 shun4
+䀶 lang3 liang4
+䀷 jie2
+䀸 di4 zhi4
+䀹 jie2 zha3 jia2 she4 ya4
+䀻 pin4
+䀼 ren4 zhen3
+䀽 yan2
+䀾 du3
+䀿 di4
+䁁 lang3 liang4
+䁂 xian4
+䁄 xing4
+䁅 bei4 bi4 meng3 meng4
+䁆 an3 yi4
+䁇 mi4
+䁈 qi4
+䁉 qi4
+䁊 wo4
+䁋 she2
+䁌 yu4
+䁍 jia4 ke4 qia4
+䁎 cheng2
+䁏 yao3
+䁐 ying4
+䁑 yang2
+䁒 ji2
+䁓 jie4 zong3
+䁔 han4 huan3
+䁕 min2
+䁖 lou1
+䁗 kai3
+䁘 yao3
+䁙 yan3 yan4
+䁚 sun3
+䁛 gui3 gui4 kui4
+䁜 huang3 huang4
+䁝 ying2
+䁞 sheng3
+䁟 cha2 duo2
+䁠 lian2
+䁢 xuan2
+䁣 chuan2
+䁤 che4 cheng4
+䁥 ni4
+䁦 qu4
+䁧 miao2
+䁨 huo4
+䁩 yu2
+䁪 nan3 zhan3
+䁫 hu2
+䁬 ceng2
+䁮 qian2
+䁯 she4 xie2
+䁰 jiang3
+䁱 ao4
+䁲 mai2
+䁳 mang3
+䁴 zhan3
+䁵 bian3
+䁶 jiao3
+䁷 jue2 wo4
+䁸 nong2
+䁹 bi4
+䁺 shi4
+䁻 li4 shuo4
+䁼 mo4 mu4
+䁽 lie4
+䁾 mie4
+䁿 mo4
+䂀 xi1
+䂁 chan2
+䂂 qu2
+䂃 jiao4 jie2
+䂄 huo4 kuang4
+䂆 xu4
+䂇 nang2 niu3 nong3 pang2
+䂈 tong2
+䂉 hou2
+䂊 yu4
+䂍 bo2
+䂎 zuan3
+䂐 chuo4
+䂒 jie2 qia4 ya4
+䂔 xing4
+䂕 hui4
+䂖 shi2 si4
+䂚 yao2 you2
+䂛 yu2
+䂜 bang4 pei2
+䂝 jie2 ze2 zhe2
+䂞 zhe4
+䂠 she2 shi3
+䂡 di3 zhi3
+䂢 dong3
+䂣 ci2
+䂤 fu4 hai2
+䂥 min2
+䂦 zhen3
+䂧 zhen3
+䂩 yan4
+䂪 diao4 tiao3
+䂫 hong2
+䂬 gong3
+䂮 lve4
+䂯 guai4 guan4
+䂰 la4
+䂱 cui4 rui4
+䂲 fa3
+䂳 cuo3
+䂴 yan2
+䂶 jie2
+䂸 guo2 xu4
+䂹 suo3
+䂺 wan3 wo3
+䂻 zheng4
+䂼 nie4
+䂽 diao4 yi4
+䂾 lai3
+䂿 ta4 tie4
+䃀 cui4 xun4
+䃂 gun3 gun4
+䃇 mian2
+䃉 min2
+䃊 ju3
+䃋 yu2
+䃍 zhao4 zhui4
+䃎 ze2 zha4
+䃑 pan2
+䃒 he2
+䃓 gou4
+䃔 hong2
+䃕 lao2 luo4
+䃖 wu4
+䃗 chuo4
+䃙 lu4
+䃚 cu4
+䃛 lian2 qian4
+䃝 qiao4
+䃞 shu2 yi4
+䃡 cen2
+䃣 hui3
+䃤 su4
+䃥 chuang2
+䃧 long2
+䃩 nao2
+䃪 tan2
+䃫 dan3
+䃬 wei3
+䃭 gan3
+䃮 da2
+䃯 li4
+䃱 xian4
+䃲 pan2 pan4
+䃳 la4
+䃵 niao3
+䃶 huai2
+䃷 ying2
+䃸 xian4
+䃹 lan4 lang3
+䃺 mo2
+䃻 ba4 pai2
+䃽 fu2 gui3 si4
+䃾 bi3
+䄀 huo4
+䄁 yi4
+䄂 liu4
+䄅 juan4
+䄆 huo2 kuo4
+䄇 cheng2
+䄈 dou4
+䄉 e2
+䄋 yan3
+䄌 zhui4
+䄍 du4 duo2 zha4
+䄎 qi3
+䄏 yu2
+䄐 quan4
+䄑 huo2 kuo4
+䄒 nie4 ren3
+䄓 heng2 huang2
+䄔 ju3
+䄕 she4 shen4 tian3
+䄘 peng2
+䄙 ming2
+䄚 cao2
+䄛 lou2
+䄜 li2
+䄝 chun3
+䄟 cui4
+䄠 shan4
+䄢 qi2
+䄤 lai4
+䄥 ling2
+䄦 liao3
+䄧 reng2 rong3
+䄨 yu2 yu3
+䄩 nao2 yi4
+䄪 chuo4 diao3
+䄫 qi3
+䄬 yi2
+䄭 nian2
+䄯 jian3 xian4
+䄰 ya2 zha2
+䄲 chui2
+䄶 bi4
+䄷 dan4 diao3 shi2
+䄸 po4
+䄹 nian2 tian3
+䄺 zhi4
+䄻 chao2 tao2 zhao4
+䄼 tian3
+䄽 tian3
+䄾 rou4
+䄿 yi4
+䅀 lie4
+䅁 an4
+䅂 he2
+䅃 qiong2
+䅄 li4
+䅆 zi4
+䅇 su4
+䅈 yuan4
+䅉 ya4
+䅊 du4
+䅋 wan3
+䅍 dong4 ting3
+䅎 you3
+䅏 hui4 wei4
+䅐 jian3 qian2
+䅑 rui2 sui2
+䅒 mang2
+䅓 ju3 qu4
+䅖 an3
+䅗 sui4
+䅘 lai2
+䅙 hun4
+䅚 qiang3 quan3 ze2
+䅜 duo4
+䅞 na4 nai4 ne4
+䅟 can3
+䅠 ti2
+䅡 xu3
+䅢 jiu4
+䅣 huang2
+䅤 qi4
+䅥 jie2
+䅦 mao2
+䅧 yan4
+䅩 zhi3
+䅪 tui2
+䅬 ai4 yan3 ye4
+䅭 pang2
+䅮 cang4
+䅯 tang2
+䅰 en3
+䅱 hun4
+䅲 qi2
+䅳 chu2
+䅴 suo3
+䅵 zhuo2
+䅶 nou4 wu3
+䅷 tu2
+䅸 zu2
+䅹 lou2 lou3
+䅺 miao3
+䅻 li2
+䅼 man2
+䅽 gu3
+䅾 cen2 qian2 qin2
+䅿 hua2
+䆀 mei3
+䆂 lian2 qian4
+䆃 dao3 dao4
+䆄 shan4
+䆅 ci2 ji3
+䆈 zhi4
+䆉 ba4
+䆊 cui4
+䆋 qiu1
+䆍 long2
+䆏 fei4
+䆐 guo2
+䆑 cheng2
+䆒 jiu4
+䆓 e4 ruan3
+䆕 jue2
+䆖 hong2
+䆗 jiao4
+䆘 cuan2
+䆙 yao2
+䆚 tong2
+䆛 cha2 zha4 zhe2
+䆜 you4
+䆝 shu4
+䆞 yao3
+䆟 ge2
+䆠 huan4
+䆡 lang2 lang4
+䆢 jue2
+䆣 chen2
+䆦 shen4
+䆨 ming2
+䆩 ming2
+䆫 chuang1 cong1
+䆬 yun3
+䆮 jin4
+䆯 chuo4
+䆱 tan3
+䆳 qiong2 sui4
+䆵 cheng2
+䆷 yu4
+䆸 cheng2
+䆹 tong3
+䆻 qiao4
+䆽 ju4 qu2 qun2
+䆾 lan2
+䆿 yi4
+䇀 rong2 rong3
+䇃 si4 xiao4
+䇅 fa2
+䇇 meng2
+䇈 gui4 hua4
+䇋 hai4 ran3 xie4
+䇌 qiao4
+䇍 chuo4
+䇎 que4
+䇏 dui4
+䇐 li4
+䇑 ba4
+䇒 jie4 qin2 xian4
+䇔 luo4 nuo4
+䇖 yun3
+䇘 hu4
+䇙 yin3
+䇛 zhi3 zhi4
+䇜 lian3
+䇞 gan3
+䇟 jian4
+䇠 zhou4 zhu4
+䇡 zhu4
+䇢 ku3
+䇣 na4 nei4 yi3
+䇤 dui4 rui4 su4
+䇥 ze2 zuo2
+䇦 yang3
+䇧 zhu4
+䇨 gong4 xiang2
+䇩 yi4
+䇬 chuang3
+䇭 lao3
+䇮 ren4
+䇯 rong2
+䇱 na4
+䇲 ce4 jia1
+䇵 yi2
+䇶 jue2
+䇷 bi3 bie2
+䇸 cheng2 sheng4 zeng4
+䇹 jun4
+䇺 chou2 dou4
+䇻 hui4 kui4 wei3
+䇼 chi4 yi4
+䇽 zhi4
+䇾 yan2
+䈁 lun2 luo4
+䈂 bing4 ping2
+䈃 zhao3
+䈄 han2
+䈅 yu4
+䈆 dai4
+䈇 zhao4
+䈈 fei2
+䈉 sha4
+䈊 ling2
+䈋 ta4
+䈍 mang2
+䈎 ye4
+䈏 bao2
+䈐 kui4
+䈑 gua3 jue2
+䈒 nan3
+䈓 ge2
+䈕 chi2 shi5 ti2
+䈗 suo3
+䈘 ci2
+䈙 zhou4
+䈚 tai2
+䈛 kuai4
+䈜 qin4
+䈞 du3
+䈟 ce4
+䈠 huan3
+䈢 sai3
+䈣 zheng4
+䈤 qian2
+䈧 wei3
+䈪 xi4
+䈫 na4
+䈬 pu2
+䈭 huai2
+䈮 ju3 ju4 wan3
+䈲 pan2
+䈳 ta4
+䈴 qian4 zhan3
+䈶 rong2
+䈷 luo4
+䈸 hu2
+䈹 sou3
+䈻 pu2
+䈼 mie4
+䈾 shuo4
+䈿 mai4 mi4
+䉀 shu4
+䉁 ling2
+䉂 lei3
+䉃 jiang3
+䉄 leng2
+䉅 zhi4
+䉆 diao3
+䉈 san3
+䉉 hu2
+䉊 fan4 fang2
+䉋 mei4
+䉌 sui4
+䉍 jian3
+䉎 tang2
+䉏 xie4
+䉑 mo2 wu2
+䉒 fan2
+䉓 lei2 luo4
+䉕 ceng2
+䉖 ling2
+䉘 cong2
+䉙 yun2
+䉚 meng2
+䉛 yu4
+䉜 zhi4
+䉝 qi3
+䉞 dan3
+䉟 huo4
+䉠 wei2
+䉡 tan2
+䉢 se4
+䉣 xie4
+䉤 sou3
+䉥 song3
+䉧 liu2 liu3
+䉨 yi4
+䉪 lei4
+䉫 li2
+䉬 fei4
+䉭 lie4
+䉮 lin4
+䉯 xian4
+䉰 yao2
+䉲 bie4 mi2
+䉳 xian3
+䉴 rang2 rang3
+䉵 zhuan4
+䉷 dan4 jin4 yan2
+䉸 bian4
+䉹 ling2 liu3
+䉺 hong2
+䉻 qi2
+䉼 liao4
+䉽 ban3
+䉾 mi4
+䉿 hu2 luo4
+䊀 hu2
+䊂 ce4 se4
+䊃 pei4
+䊄 qiong2
+䊅 ming2
+䊆 jiu4 qiu3
+䊇 bu4
+䊈 mei2
+䊉 san3
+䊊 mei4
+䊍 li2
+䊎 quan3
+䊐 en4 hua2 huan4 hun2
+䊑 xiang3
+䊓 shi4
+䊖 lan3 nan3
+䊗 huang2 huang3
+䊘 jiu4
+䊙 yan2
+䊛 sa3
+䊜 tuan2
+䊝 xie4
+䊞 zhe2
+䊟 men2
+䊠 xi4
+䊡 man2
+䊣 huang2
+䊤 tan2
+䊥 xiao4
+䊦 ya2 ye4
+䊧 bi4
+䊨 luo2
+䊩 fan2 fan4
+䊪 li4
+䊫 cui3 mi2
+䊬 cha4
+䊭 chou2 dao4
+䊮 di2 zhe2 zhe4
+䊯 kuang4
+䊰 chu3
+䊲 chan3
+䊳 mi2
+䊴 qian4
+䊵 qiu2
+䊶 zhen4
+䊺 gu3 hu4
+䊻 yan3
+䊼 chi3
+䊽 guai4
+䊾 mu4
+䊿 bo2 ku4
+䋀 kua4
+䋁 geng3
+䋂 yao2
+䋃 mao4
+䋄 wang3
+䋈 ru2
+䋉 jue2 ke3 xue2
+䋋 min2
+䋌 jiang3
+䋎 zhan4
+䋏 zuo4
+䋐 yue4
+䋑 bing3
+䋓 zhou4
+䋔 bi4
+䋕 ren4
+䋖 yu4
+䋘 chuo4 zhui4
+䋙 er3
+䋚 yi4
+䋛 mi2 mi3
+䋜 qing4
+䋞 wang3
+䋟 ji4
+䋠 bu3
+䋢 bie4
+䋣 fan2 pan2
+䋤 yao4 yue4
+䋥 li2
+䋦 fan2
+䋧 qu2
+䋨 fu3
+䋩 er2
+䋭 huo4 yu4
+䋮 jin4 qian2
+䋯 qi3 qing4
+䋰 ju2
+䋱 lai2
+䋲 che3 sheng2 xing3 zhe4
+䋳 bei4 mi4
+䋴 niu4 rong3 rou2 ru3
+䋵 yi4
+䋶 xu4
+䋷 liu2 mou2
+䋸 xun2
+䋹 fu2 fu4
+䋻 nin2
+䋼 ting3 ying2
+䋽 beng3 peng3
+䋾 zha3
+䌂 ou4
+䌃 shuo4
+䌄 geng3
+䌅 tang2
+䌆 gui4
+䌇 hui4 suo3
+䌈 ta4
+䌊 yao2 you2
+䌌 qi4 qie4 qu3
+䌍 han4 jin3
+䌎 lve4
+䌏 mi4 mian4
+䌐 mi4
+䌒 lu4
+䌓 fan2
+䌔 ou4
+䌕 mi2 mo2
+䌖 jie2
+䌗 fu3
+䌘 mi2
+䌙 huang3
+䌚 su4
+䌛 yao2
+䌜 nie4
+䌝 jin4
+䌞 lian3
+䌟 bi4
+䌠 qing4 yan3 yin4
+䌡 ti3
+䌢 ling2
+䌣 zuan3
+䌤 zhi3
+䌥 yin3
+䌦 dao3
+䌧 chou2
+䌨 cai4
+䌩 mi4 mie4
+䌪 yan2
+䌫 lan3
+䌬 chong2
+䌯 guan4 quan2
+䌰 she4
+䌱 luo4
+䌴 luo4
+䌵 zhu2 zhu3
+䌷 chou2 chou1
+䌸 juan4
+䌹 jiong3
+䌺 er3
+䌻 yi4
+䌼 rui4
+䌽 cai3
+䌾 ren2
+䌿 fu2
+䍀 lan2
+䍁 sui4
+䍂 yu2
+䍃 yao2 you2
+䍄 dian3
+䍅 ling2
+䍆 zhu4
+䍇 ta4
+䍈 ping2
+䍉 qian2 zhai3
+䍊 jue2
+䍋 chui2
+䍌 bu4 fu2
+䍍 gu3 gu4 guang4 kou4
+䍎 cun4
+䍐 han3 han4
+䍑 han3
+䍒 mou3
+䍓 hu4 ya2
+䍔 hong2
+䍕 di3
+䍖 fu2 fu4 hai4 xie4
+䍗 xuan4
+䍘 mi2
+䍙 mei2
+䍚 lang4
+䍛 gu4
+䍜 zhao4
+䍝 ta4 zan3
+䍞 yu4
+䍟 zong4
+䍠 li2
+䍡 liao4 lu4
+䍢 wu2 wu3
+䍣 lei2
+䍤 ji3
+䍥 lei4 li4
+䍦 li2
+䍨 bo2 fei4
+䍩 ang3 yang3
+䍪 kui4 wa4
+䍫 tuo2
+䍮 zhao4
+䍯 gui3 ji4
+䍱 xu2
+䍲 nai2 ni2 ni4
+䍳 chuo4 jue2 que4
+䍴 duo4 rui2 wei3
+䍶 dong4
+䍷 gui4 hui4 wei3
+䍸 bo2
+䍺 huan2
+䍻 xuan3
+䍼 can2
+䍽 li4
+䍾 tui2 yan3
+䍿 huang2
+䎀 xue4 yue4
+䎁 hu2
+䎂 bao3
+䎃 ran3
+䎄 tiao2
+䎅 fu4 luo4 po4
+䎆 liao4
+䎈 yi4
+䎉 shu4 yu4
+䎊 po4
+䎋 he4 kao4
+䎌 cu4
+䎎 na4
+䎏 an4 han2
+䎐 chao3
+䎑 lu4
+䎒 zhan3
+䎓 ta4
+䎗 qiao2
+䎘 su4
+䎚 guan4 hui4
+䎝 chu2 zhu4
+䎟 er2 nuo4
+䎠 er2
+䎡 nuan3 ruan3
+䎢 qi3
+䎣 si4 xin4
+䎤 chu2 ju2
+䎦 yan3
+䎧 bang4 pou2
+䎨 an4 ye4
+䎪 ne4
+䎫 chuang4 zong3
+䎬 ba4 pa2
+䎮 ti4
+䎯 han4
+䎰 zuo2
+䎱 ba4 pa2
+䎲 zhe2
+䎳 wa4 yue4
+䎴 sheng4
+䎵 bi4
+䎶 er4
+䎷 zhu4
+䎸 wu4
+䎹 wen2
+䎺 zhi3 zhi4
+䎻 zhou3
+䎼 lu4
+䎽 wen2 wen4
+䎾 gun3
+䎿 qiu2 xiong4
+䏀 la4
+䏁 zai3
+䏂 sou3
+䏃 mian2
+䏄 zhi4
+䏅 qi4
+䏆 cao2 chua4 qiao2
+䏇 piao4
+䏈 lian2
+䏊 long2
+䏋 su4
+䏌 qi4 yi4
+䏍 yuan4
+䏎 feng2 han4
+䏐 jue2 zhuo4
+䏑 di4 zhi4
+䏒 pian4
+䏓 guan3
+䏔 niu3
+䏕 ren3 run4
+䏖 zhen4
+䏗 gai4 kui4
+䏘 pi3 pi4
+䏙 tan3
+䏚 chao3
+䏛 chun3
+䏝 chun2 zhuan3
+䏞 mo4
+䏟 bie4
+䏠 qi4
+䏡 shi4
+䏢 bi3
+䏣 jue2 qu4
+䏤 si4
+䏦 hua2 tian2 wan3
+䏧 na2
+䏨 hui3
+䏪 er4
+䏬 mou2
+䏮 xi2 xie2
+䏯 zhi4
+䏰 ren3
+䏱 ju2
+䏲 die2
+䏳 zhe4
+䏴 shao4 she4
+䏵 meng3
+䏶 bi4
+䏷 han4
+䏸 yu2
+䏹 xian4
+䏻 neng2
+䏼 can2
+䏽 bu4
+䏿 qi3
+䐀 ji4
+䐁 niao3 zhuo2
+䐂 lu4
+䐃 jiong3
+䐄 han4 lian3 xian4
+䐅 yi2
+䐆 cai3 cai4
+䐇 chun2
+䐈 zhi2
+䐉 zi4
+䐊 da2 hun2 hun4
+䐌 tian3 zhou4
+䐍 zhou4
+䐏 chun3
+䐑 zhe2
+䐓 rou2 ru4
+䐔 bin4
+䐕 ji2
+䐖 yi2
+䐗 du3
+䐘 jue2
+䐙 ge2 yi4
+䐚 ji2 ji4
+䐝 suo3
+䐞 ruo4
+䐟 xiang4
+䐠 huang3
+䐡 qi2
+䐢 zhu4
+䐣 cuo4 sun3
+䐤 chi2 cuo2 qi4 zhan4
+䐥 weng3
+䐧 kao4
+䐨 gu3
+䐩 kai3
+䐪 fan4 juan3
+䐬 cao2
+䐭 zhi4
+䐮 chan3
+䐯 lei2
+䐲 zhe2
+䐳 yu2
+䐴 gui4
+䐵 huang2
+䐶 jin3
+䐸 guo2 huo4
+䐹 sao4
+䐺 tan4
+䐼 xi4
+䐽 man2
+䐾 duo2
+䐿 ao2 ao4 bi4
+䑀 pi4
+䑁 wu4
+䑂 ai3 xi4
+䑃 meng2
+䑄 pi4 yi4
+䑅 meng2
+䑆 yang3
+䑇 zhi4
+䑈 bo2
+䑉 ying2
+䑊 wei2 wei4
+䑋 nao2 rang3
+䑌 lan2
+䑍 yan4 ying3
+䑎 chan3
+䑏 quan2
+䑐 zhen3
+䑑 pu2
+䑓 tai2 tai3
+䑔 fei4
+䑕 shu3
+䑗 dang4
+䑘 cha2 cuo2
+䑙 ran2
+䑚 tian2
+䑛 chi3 shi4 yi4
+䑜 ta4
+䑝 jia3
+䑞 shun4
+䑟 huang2
+䑠 liao3
+䑤 jin4 jing4
+䑥 e4 sa4
+䑧 fu2
+䑨 duo4
+䑪 e4
+䑬 yao4
+䑭 di4 zhi4
+䑯 di4
+䑰 bu4
+䑱 man2 wan3
+䑲 che4 zhai2 zhao4
+䑳 lun2
+䑴 qi2
+䑵 mu4
+䑶 can2 qian4
+䑻 you2
+䑽 da2 ta4
+䑿 su4
+䒀 fu2
+䒁 ji4 xi2 xiao4 ya4
+䒂 jiang3 xiang3
+䒃 cao4 zao4
+䒄 bo2 fu4
+䒅 teng2
+䒆 che4
+䒇 fu4
+䒈 bu3 fe4 fei4
+䒉 wu3
+䒋 yang3
+䒌 ming4
+䒍 pang3
+䒎 mang3
+䒐 meng2
+䒑 cao3
+䒒 tiao2 yao3 you2
+䒓 kai3
+䒔 bai4
+䒕 xiao3
+䒖 xin4
+䒗 qi4
+䒚 shao3
+䒛 heng2 huan4
+䒜 niu2
+䒝 xiao2
+䒞 chen2
+䒠 fan3 xia2
+䒡 yin3
+䒢 ang2 ying4
+䒣 ran3
+䒤 ri4
+䒥 fa4 liu3 man2
+䒦 fan4
+䒧 qu4
+䒨 shi3
+䒩 he2 xia2
+䒪 bian4
+䒫 dai4
+䒬 mo4
+䒭 deng3
+䒲 cha4
+䒳 duo3
+䒴 you3
+䒵 hao4
+䒸 xian2 xue4 yue4
+䒹 lei4
+䒺 jin3
+䒻 qi3
+䒽 mei2 wang3
+䓂 yan2
+䓃 yi4
+䓄 yin2
+䓅 qi2
+䓆 zhe2
+䓇 xi4
+䓈 yi4
+䓉 ye2
+䓊 e4 wu2 yu2
+䓌 zhi4
+䓍 han3
+䓎 chuo4
+䓐 chun2
+䓑 bing3 ping2
+䓒 kuai3
+䓓 chou2
+䓕 tuo3 wei3
+䓖 qiong2
+䓘 jiu4
+䓚 cu2
+䓛 fu3 gu3
+䓝 meng2 meng4
+䓞 li4
+䓟 lie4
+䓠 ta4
+䓢 gu4
+䓣 liang3
+䓥 la4
+䓦 dian3
+䓧 ci4 ji2
+䓫 ji4 qi2
+䓭 cha4
+䓮 mao4
+䓯 du2
+䓱 chai2 zhai4
+䓲 rui4 sa4
+䓳 hen3
+䓴 ruan2 ruan3
+䓶 lai4
+䓷 xing4
+䓹 yi4
+䓺 mei3 wei4
+䓼 he4 mang2
+䓽 ji4
+䓿 han3 han4
+䔁 li4
+䔂 zi3
+䔃 zu3
+䔄 yao2
+䔆 li2
+䔇 qi3 yi3
+䔈 gan3 gong4 nou3
+䔉 li4
+䔎 su4
+䔏 chou4
+䔑 xie2 ye2
+䔒 bei4
+䔓 xu3
+䔔 jing4 qian3 qiu2 ying3
+䔕 pu2
+䔖 ling2
+䔗 xiang2
+䔘 zuo4
+䔙 diao4
+䔚 chun2
+䔛 qing3
+䔜 nan2
+䔞 lv4
+䔟 chi2 chi3 yi2
+䔠 shao3
+䔡 yu2
+䔢 hua2 hua4
+䔣 li2
+䔧 li2 li4
+䔪 dui4 shuang3
+䔬 yi4
+䔭 ning4 zhou3
+䔯 hu2 hua4 ku4
+䔰 fu2 fu4
+䔲 cheng2 zhuo2
+䔳 nan3 ran2
+䔴 ce4 cui4
+䔶 ti2
+䔷 qin2
+䔸 biao3
+䔹 sui4
+䔺 wei2
+䔼 se4
+䔽 ai4
+䔾 e4 qi4 ze4
+䔿 jie4 zun3
+䕀 kuan3
+䕁 fei3
+䕃 yin4
+䕅 sao3
+䕆 dou4
+䕇 hui4
+䕈 xie4
+䕉 ze2
+䕊 tan2
+䕋 chang3 tang2
+䕌 zhi4
+䕍 yi4
+䕎 fu2
+䕏 e2
+䕑 jun4
+䕓 cha2 chui4
+䕔 xian2
+䕕 man4
+䕗 bi4 pei4
+䕘 ling2
+䕙 jie2
+䕚 kui4
+䕛 jia2
+䕞 lang4 liao2
+䕠 fei4
+䕡 lu3 lv2
+䕢 zha3
+䕣 he2 ke3 she2
+䕥 ni3 yi2
+䕦 ying2
+䕧 xiao4
+䕨 teng2
+䕩 lao3 lao4
+䕪 ze2
+䕫 kui2
+䕭 qian2
+䕮 ju2
+䕯 piao2
+䕰 ban4 fan2 fan4
+䕱 dou3 dou4 tou2
+䕲 lin3
+䕳 mi2
+䕴 zhuo2
+䕵 xie2 xie4
+䕶 hu4
+䕷 mi2
+䕹 za2
+䕺 cong2
+䕻 ge2 li4
+䕼 nan2 nan4
+䕽 zhu2
+䕾 yan2 yin2
+䕿 han4
+䖁 yi4
+䖂 luan2
+䖃 yue4
+䖄 ran2
+䖅 ling2
+䖆 niang4
+䖇 yu4
+䖈 nue4
+䖊 yi2 yi4
+䖋 nue4
+䖌 qin2 ya2 yi4
+䖍 qian2
+䖎 xia2
+䖏 chu3
+䖐 jin4 yin2
+䖑 mi4
+䖓 na4
+䖔 han4 kan3
+䖕 zu3
+䖖 xia2
+䖗 yan2 yan4
+䖘 tu2
+䖛 suo3
+䖜 yin2 yin4
+䖝 chong2
+䖞 zhou3
+䖟 mang3 meng2
+䖠 yuan2
+䖡 nv4
+䖢 miao2
+䖣 sao4 ye4 zao3
+䖤 wan3 yuan2
+䖥 li2 mao2
+䖧 na4
+䖨 shi2
+䖩 bi4 pi4
+䖪 ci2
+䖫 bang4
+䖭 juan4
+䖮 xiang3
+䖯 gui4 kui2
+䖰 pai4
+䖲 xun2
+䖳 zha4
+䖴 yao2
+䖸 e2
+䖹 yang2
+䖺 tiao2 zhao4
+䖻 you2
+䖼 jue2 xue4
+䖽 li2
+䖿 li2
+䗁 ji4
+䗂 hu3
+䗃 zhan4
+䗄 fu3 pi4
+䗅 chang2
+䗆 guan3 wei3
+䗇 ju2 qu2
+䗈 meng2
+䗊 cheng2 tan4
+䗋 mou2
+䗍 li3
+䗑 yi4
+䗒 bing4
+䗔 hou2
+䗕 wan3
+䗖 chi4 di4 ti2 zhe4
+䗘 ge2 ke4
+䗙 han2
+䗚 bo2
+䗜 liu2
+䗝 can2
+䗞 can2 chen3 shan3 yin3 zan4 zhan4
+䗟 yi4
+䗠 xuan2
+䗡 yan2
+䗢 suo3 zao3
+䗣 gao3 han4
+䗤 yong2
+䗨 yu2
+䗪 zhe4
+䗫 ma2
+䗮 shuang3
+䗯 jin4
+䗰 guan4
+䗱 pu2
+䗲 lin4
+䗴 ting2
+䗶 la4 li4
+䗷 yi4
+䗹 ci4
+䗺 yan3
+䗻 jie2
+䗽 wei4
+䗾 xian3
+䗿 ning2
+䘀 fu4
+䘁 ge2 jie2 ke3
+䘃 mo4
+䘄 fu4 zhu4
+䘅 nai2 nai4 neng3
+䘆 xian3
+䘇 wen2 wen4
+䘈 li4
+䘉 can2
+䘊 mie4
+䘌 ni4
+䘍 chai4
+䘏 xu4
+䘐 nv4
+䘑 mai4 mo4
+䘓 kan4 kao4
+䘕 hang2
+䘘 yu4
+䘙 wei4
+䘚 zhu2
+䘝 yi4
+䘠 fu2 po4
+䘡 bi3
+䘢 zhu3
+䘣 zi3
+䘤 shu4
+䘥 xia2
+䘦 ni2 ni3
+䘨 jiao3
+䘩 xuan4 xun2
+䘫 nou4 ru2
+䘬 rong2
+䘭 die2 zhi4
+䘮 sa4 sang4 xi4
+䘱 yu4
+䘵 lu4
+䘶 han4 yan3
+䘸 yi4
+䘹 zui4
+䘺 zhan4
+䘻 su4 yu4
+䘼 wan3
+䘽 ni2 ni3 ni4
+䘾 guan3
+䘿 jue2
+䙀 beng3
+䙁 can2
+䙃 duo4 kuo4 pan2 ruan2
+䙄 qi4 zha3
+䙅 yao4
+䙆 gui4 kui4
+䙇 nuan3 ruan2
+䙈 hou2
+䙉 xun2 zan3
+䙊 xie4
+䙌 hui4 kui4
+䙎 xie2
+䙏 bo2
+䙐 ke4
+䙒 xu4
+䙓 bai3 he4
+䙕 chu4 zong3
+䙗 ti4
+䙘 chu3 zu2
+䙙 chi2
+䙚 niao3
+䙛 guan4 gun3
+䙜 feng2
+䙝 xie4
+䙟 duo4 wei2
+䙠 jue2 wo4
+䙡 hui4 kui4
+䙢 zeng4
+䙣 sa4
+䙤 duo3 duo4
+䙥 ling2
+䙦 meng2
+䙨 guo3 luo3
+䙩 meng2
+䙪 long2 mang4 pan4
+䙬 ying4
+䙮 guan4
+䙯 cu4 zhuo2
+䙰 li2
+䙱 du2 shu3
+䙳 e4
+䙷 de2 zhe2
+䙸 de2 de5
+䙹 jiang3 nao3 xian4 xiang3
+䙺 lian2 lian3 qian3
+䙼 shao4
+䙽 xi4 xie2
+䙿 wei4
+䚂 he4 xi4
+䚃 you2
+䚄 lu4
+䚅 lai2 lai4
+䚆 ou3 yao3 ying3
+䚇 sheng3 zhi4
+䚈 juan4 wu4 zhuan4
+䚉 qi4 xi4
+䚋 yun4
+䚍 qi4
+䚏 leng4 li4 lin4
+䚐 ji2
+䚑 mai2
+䚒 chuang2 zhuang4
+䚓 nian3 shen3
+䚕 li4 luan2
+䚖 ling2
+䚘 chen2 cheng2
+䚚 xian3
+䚛 hu2
+䚝 zu2
+䚞 dai3
+䚟 dai3
+䚠 hun4
+䚢 che4
+䚣 ti2 ti4
+䚥 nuo4
+䚦 zhi4
+䚧 liu2
+䚨 fei4
+䚩 jiao3 jiao4
+䚫 ao2 xi2
+䚬 lin2
+䚮 reng2
+䚯 tao3 zhen4
+䚰 pi3
+䚱 xin4
+䚲 shan4
+䚳 xie4 zhi4
+䚴 wa4
+䚵 tao3
+䚷 xi4 yi3 yi4
+䚸 xie4
+䚹 pi3
+䚺 yao2
+䚻 yao2
+䚼 nv4
+䚽 hao4
+䚾 nin2 ren2
+䚿 yin4
+䛀 fan3
+䛁 nan2
+䛂 chi2 chi3
+䛃 wang4
+䛄 yuan3
+䛅 xia2
+䛆 zhou4
+䛇 yuan3
+䛈 shi4
+䛉 mi4 mian4
+䛋 ge2 ji4
+䛌 pao2 tao2
+䛍 fei4
+䛎 hu4 xue4 yu4
+䛏 ni2
+䛐 ci2
+䛑 mi4
+䛒 bian4
+䛔 na2
+䛕 yu4
+䛖 e4 yi4
+䛗 zhi3
+䛘 nin2 ren2
+䛙 xu4
+䛚 lve4
+䛛 hui4 qi4
+䛜 xun4
+䛝 nao2
+䛞 han3 han4
+䛟 jia2
+䛠 dou4 xiang2
+䛡 hua4
+䛤 cu4
+䛥 xi4
+䛦 song4
+䛧 mi2
+䛨 xin4
+䛩 wu4
+䛪 qiong2 wei3
+䛫 zheng4
+䛬 chou2 tao2
+䛭 xing4
+䛮 jiu4
+䛯 ju4
+䛰 hun2 hun4
+䛱 ti2
+䛲 man2 man4
+䛳 jian3 yan4
+䛴 qi3
+䛵 shou4
+䛶 lei3
+䛷 wan3
+䛸 che4 shan3
+䛹 can4
+䛺 jie4
+䛻 you4
+䛼 hui3
+䛽 zha3
+䛾 su4
+䛿 ge2
+䜀 nao3
+䜁 xi4
+䜄 chi2
+䜅 wei2
+䜆 mo4 nei4 she2 sui4 zhe2
+䜇 gun3 gun4
+䜊 zao4 zuo4
+䜋 hui4
+䜌 luan2
+䜍 liao2
+䜎 lao2 lao4
+䜑 qia4 wu4
+䜒 ao4
+䜓 nie4 she4
+䜔 sui2
+䜕 mai4
+䜖 tan4
+䜗 xin4
+䜘 jing3
+䜙 an2
+䜚 ta4
+䜛 chan2 chan4
+䜜 wei4
+䜝 tuan3
+䜞 ji4
+䜟 chen2 chen4
+䜠 che4 zhi4
+䜡 xu4 xue4 yu4
+䜢 xian3
+䜣 xin1 xi1 yin2
+䜧 nao3
+䜩 yan4
+䜪 qiu2
+䜫 hong2
+䜬 song3 xiu4
+䜭 jun4
+䜮 liao2
+䜯 ju2
+䜱 man3
+䜲 lie4
+䜴 chu4 shi4
+䜵 chi3 shi4
+䜶 xiang2
+䜸 mei3
+䜹 shu4
+䜺 ce4
+䜻 chi3 shi4
+䜼 gu2
+䜽 yu2
+䝀 liao2 liu2
+䝁 lao2
+䝂 shu4
+䝃 zhe2
+䝈 e4
+䝊 sha4
+䝋 zong4
+䝌 jue2 jun4
+䝍 jun4
+䝏 lou2 lou3 lv2
+䝐 wei2
+䝒 zhu4
+䝓 la4 lie4
+䝕 zhe2
+䝖 zhao3
+䝘 yi4
+䝚 ni2
+䝝 yi3
+䝞 hao4
+䝟 ya4 ye4
+䝠 huan2 yuan2
+䝡 man4
+䝢 man4 meng2
+䝣 qu2
+䝤 lao3
+䝥 hao2
+䝧 men2 min2
+䝨 xian2
+䝩 zhen4
+䝪 shu2 shu3
+䝫 zuo2
+䝬 zhu4
+䝭 gou4
+䝮 xuan4
+䝯 yi4
+䝰 ti2 zhi4
+䝲 jin4
+䝳 can2
+䝵 bu4
+䝶 liang2
+䝷 zhi4
+䝸 ji4
+䝹 wan3 yuan4
+䝺 guan4
+䝼 qing2
+䝽 ai4
+䝾 fu4
+䝿 gui4
+䞀 gou4 hou4 min3
+䞁 xian4 yan4 yang3 yang4
+䞂 ruan3
+䞃 zhi4
+䞄 biao4
+䞅 yi2
+䞆 suo3
+䞇 die2 zhi4
+䞈 gui3 gui4
+䞉 sheng4
+䞊 xun4
+䞋 chen4
+䞌 she2
+䞍 qing2
+䞐 chun3 shun3
+䞑 hong2
+䞒 dong4
+䞓 cheng1
+䞔 wei3
+䞕 die2 na3 nie4 ru2 xie4 yu2
+䞖 shu3
+䞘 ji2
+䞙 za2
+䞚 qi2
+䞜 fu4
+䞝 ao3 yu4
+䞞 fu2
+䞟 po4
+䞡 tan3
+䞢 zha4 zuo2
+䞣 che3
+䞤 qu2
+䞥 you4
+䞦 he2 jie2
+䞧 hou4
+䞨 gui3
+䞩 e4 rui2
+䞪 jiang4
+䞫 yun3
+䞬 tou4
+䞭 qiu3
+䞯 fu4
+䞰 zuo2
+䞱 hu2
+䞳 bo2 fei4
+䞵 jue3
+䞶 di4 ti4
+䞷 jue2
+䞸 fu4
+䞹 huang2
+䞻 yong3
+䞼 chui3 cuan4 jian4 mei4
+䞽 suo3
+䞾 chi2
+䟂 man2
+䟃 ca4 zan4
+䟄 qi4 zuo2
+䟅 jian4 zan4
+䟆 bi4 bo2
+䟈 zhi2
+䟉 zhu2
+䟊 qu2
+䟋 zhan3 zhan4
+䟌 ji2 jie2
+䟍 dian2
+䟏 li4
+䟐 li4
+䟑 la3 yue4
+䟒 quan2
+䟔 fu4
+䟕 cha4
+䟖 tang4
+䟗 shi4
+䟘 hang4
+䟙 qie4
+䟚 qi2
+䟛 bo2
+䟜 na4
+䟝 tou4
+䟞 chu2
+䟟 cu4
+䟠 yue4
+䟡 di4
+䟢 chen2 jian4 nian3
+䟣 chu4
+䟤 bi4
+䟥 mang2 meng2
+䟦 ba2 bo2 yuan2
+䟧 tian2
+䟨 min2
+䟩 lie3
+䟪 feng3
+䟬 qiu4
+䟭 tiao2
+䟮 fu2
+䟯 kuo4
+䟰 jian3
+䟴 zhen4
+䟵 qiu2
+䟶 cuo4 zuo4
+䟷 chi4
+䟸 kui2
+䟹 lie4 lin4
+䟺 bang3 bei4 pei4
+䟻 du4
+䟼 wu3
+䟾 jue3 zhuo2
+䟿 lu4
+䠀 chang3
+䠂 chu2 chu3
+䠃 liang3
+䠄 tian3
+䠅 kun3 ta4
+䠆 chang2
+䠇 jue2
+䠈 tu2
+䠉 hua4 huan4 hui3
+䠊 fei4
+䠋 bi3 bi4 ma4
+䠍 qia2
+䠎 wo4
+䠏 ji4
+䠐 qu4
+䠑 kui3
+䠒 hu2
+䠓 cu4 jiu4 qu4
+䠔 sui4
+䠗 qiu4
+䠘 pi4
+䠙 bei4 pang2 pao2
+䠚 wa4
+䠛 jiao3 xiao4 yao2
+䠜 rong2
+䠞 cu4 qi2
+䠟 die2 she4
+䠠 chi4
+䠡 cuo2
+䠢 meng4
+䠣 xuan3 xuan4
+䠤 duo3 duo4
+䠥 bie2
+䠦 zhe4 zhi4
+䠧 chu2
+䠨 chan4 ma4
+䠩 gui4
+䠪 duan4
+䠫 zou4
+䠬 deng4
+䠭 lai2 lai4
+䠮 teng2
+䠯 yue4
+䠰 quan2
+䠱 shu3 zhu2
+䠲 ling2
+䠴 qin3 yin3 zhen3
+䠵 fu4
+䠶 she4
+䠷 tiao3
+䠹 ai2 hai2
+䠻 qiong2
+䠼 diao4 shu4 xue4 zhu2
+䠽 hai2
+䠾 shan3 shan4
+䠿 wai4
+䡀 zhan3
+䡁 long3
+䡂 jiu4
+䡃 li4
+䡅 min3 xian3 xun2 zhen4 zuan3
+䡆 rong2 rong3
+䡇 yue4
+䡈 jue2
+䡉 kang3
+䡊 fan2 fan3 pei4
+䡋 qi2
+䡌 hong2
+䡍 fu2 fu3
+䡎 lu2
+䡏 hong2
+䡐 tuo2
+䡑 min2
+䡒 tian2
+䡓 juan4
+䡔 qi3
+䡕 zheng3
+䡖 jing4
+䡗 gong3
+䡘 tian2
+䡙 lang2
+䡚 mao4
+䡛 yin4
+䡜 lu4
+䡝 yun3
+䡞 ju2
+䡟 pi4
+䡡 xie2
+䡢 bian4
+䡥 rong2
+䡦 sang3
+䡧 wu3
+䡨 cha4 chai2 yin2
+䡩 gu3 hou4 tou3 zhen3
+䡪 chan2 shan4
+䡫 peng2
+䡬 man4
+䡯 shuang4 zong3
+䡰 keng3
+䡱 zhuan3
+䡲 chan2
+䡴 chuang2
+䡵 sui4
+䡶 bei4 pi4
+䡷 kai4
+䡹 zhi4
+䡺 wei4
+䡻 min2
+䡼 ling2
+䡾 nei4
+䡿 ling2
+䢀 qi4
+䢁 yue4
+䢃 yi4
+䢄 xi3
+䢅 chen2
+䢇 rong3 rou3
+䢈 chen2 qin2
+䢉 nong2
+䢊 you2
+䢋 ji4
+䢌 bo2
+䢍 fang3 fen4
+䢐 cu2
+䢑 di3
+䢓 yu2
+䢔 ge2 he2 jia2
+䢕 xu4
+䢖 lv4 yu4
+䢗 he2 qu3
+䢙 bai4
+䢚 gong4 hang2
+䢛 jiong3
+䢝 ya4
+䢞 nu4 shu4
+䢟 you2
+䢠 song4
+䢡 xie4
+䢢 cang4
+䢣 yao2
+䢤 shu4
+䢥 yan2 yan4
+䢦 shuai4
+䢧 liao4 lin3 que4
+䢩 yu4
+䢪 bo2 cui4 jiao3 nu3 qian2
+䢫 sui2
+䢭 yan4
+䢮 lei4
+䢯 lin2
+䢰 tai2 ti4
+䢱 du2 zha4
+䢲 yue4
+䢳 ji3 ji4
+䢵 yun2
+䢹 ju3
+䢻 chen2 jin4 tan2
+䢽 xiang4
+䢾 xian3
+䣀 gui3 wei2
+䣁 yu3
+䣂 lei3
+䣄 tu2
+䣅 chen2
+䣆 xing2
+䣇 qiu2
+䣈 hang4 liao2 xiang4
+䣊 dang3
+䣋 cai3
+䣌 di3
+䣍 yan3
+䣑 chan2
+䣓 li2
+䣔 suo3 suo4
+䣕 ma3
+䣖 ma3
+䣘 tang2
+䣙 pei2
+䣚 lou2 lv2
+䣜 cuo2
+䣝 tu2
+䣞 e4
+䣟 can2
+䣠 jie2 ti4
+䣡 ti2 yi2
+䣢 ji2
+䣣 dang3 dao4
+䣤 jiao4 jue2
+䣥 bi3 mi4
+䣦 lei4
+䣧 yi4
+䣨 chun2
+䣩 chun2
+䣪 po4
+䣫 li2
+䣬 zai3
+䣭 tai4
+䣮 po4
+䣯 tian3
+䣰 ju4 yuan4
+䣱 xu4 yi4
+䣲 fan4
+䣴 xu4
+䣵 er4
+䣶 huo2 tian2
+䣸 ran3
+䣹 fa2
+䣼 liang2
+䣽 ti3
+䣾 mi4
+䤁 cen2 che4 she4
+䤂 mei2
+䤃 yin4
+䤄 mian3 zhuan4
+䤅 tu2
+䤆 kui2
+䤉 mi4 ming2 mo4 ru2
+䤊 rong2
+䤋 guo2 yu4
+䤍 mi2
+䤎 ju2
+䤏 pi3
+䤐 jin3
+䤑 wang4
+䤒 ji3 ji4
+䤓 meng2
+䤔 jian4 niu2 xiang4
+䤕 xue4
+䤖 bao4
+䤗 gan3
+䤘 chan3 qian3
+䤙 li4
+䤚 li3 lve4
+䤛 qiu2
+䤜 dun4
+䤝 ying4
+䤞 yun3
+䤟 chen2
+䤠 ji1 zhi3
+䤡 ran3
+䤣 lve4
+䤥 gui3
+䤦 yue4
+䤧 hui4
+䤨 pi4
+䤩 cha2
+䤪 duo3
+䤫 chan2
+䤭 kuan4 shi4 sui4 yi2
+䤮 she4
+䤯 xing2
+䤰 weng3 ying2
+䤱 shi4
+䤲 chi4
+䤳 ye4
+䤴 han2
+䤵 fei4
+䤶 ye4
+䤷 yan2 yan3
+䤸 zuan4
+䤺 yin3
+䤻 duo4
+䤼 xian4
+䤿 qie4
+䥀 chan3
+䥁 han2
+䥂 meng4
+䥃 yue4
+䥄 cu4 zan3 zan4
+䥅 qian4 qin2
+䥆 jin3 qin2 rou4 wei4
+䥇 shan4
+䥈 mu3
+䥌 zheng4
+䥍 zhi4
+䥎 chun2
+䥏 yu3
+䥐 mou2
+䥑 wan4
+䥒 chou2 jiang4
+䥔 su4
+䥕 pie3
+䥖 tian2
+䥗 kuan3
+䥘 cu4 cuo4
+䥙 sui4
+䥛 jie2
+䥜 jian4
+䥝 ao2
+䥞 jiao3
+䥟 ye4
+䥡 ye4
+䥢 long2
+䥣 zao2
+䥤 bao2 fu2
+䥥 lian2
+䥧 huan2 xuan2
+䥨 lv4
+䥩 wei2
+䥪 xian3
+䥫 tie3
+䥬 bo2
+䥭 zheng4
+䥮 zhu2
+䥯 ba4 bai4
+䥰 meng4
+䥱 xie3
+䥵 xiao3
+䥶 li4
+䥷 zha2
+䥸 mi2
+䥺 ye2
+䥾 xie3
+䦂 shan4
+䦅 shan4 zhan3
+䦆 jue2
+䦇 ji4
+䦈 fang3 han3 ji2 mou3 za2 zuo3
+䦊 niao3
+䦋 ao2
+䦌 chu4 po4 rui4
+䦍 wu4
+䦎 guan3
+䦏 xie4
+䦐 ting3
+䦑 xie4
+䦒 dang4
+䦔 tan3
+䦖 xia2 xie2
+䦗 xu4
+䦘 bi4 xian3 xian4
+䦙 si4
+䦚 huo4 kua3 kua4
+䦛 zheng4 zhi4
+䦜 wu2 wu4
+䦞 run4
+䦟 chuai4
+䦠 shi3
+䦡 huan2
+䦢 kuo4
+䦣 fu4
+䦤 chuai4 wen3
+䦥 xian2
+䦦 qin2
+䦧 qie2 xi4 yan3
+䦨 lan2
+䦪 ya4
+䦬 que4
+䦮 chun3
+䦯 zhi4
+䦱 kui3 wei3
+䦲 qian4 yan2
+䦳 hang4 xiang4
+䦴 yi4
+䦵 ni3
+䦶 zheng4
+䦷 chuai4 wen3
+䦹 shi2
+䦻 ci4 zi3
+䦼 jue2
+䦽 xu4
+䦾 yun3
+䧁 chu4 xu3
+䧂 dao4 tiao3 zhao4
+䧃 dian4 tian2
+䧄 ge4
+䧅 ti4 ya4 yi2
+䧆 hong2 kou3 qiong2
+䧇 ni3 yi3
+䧉 li3
+䧋 xian3
+䧍 xi4
+䧎 xuan4
+䧒 lai2 lan3
+䧔 mu4 nian4
+䧕 cheng2 yu4
+䧖 jian4
+䧗 bi4
+䧘 qi2 zhuan4
+䧙 ling2
+䧚 hao4
+䧛 bang4
+䧜 tang2
+䧝 di4 yi2 zhi4
+䧞 fu4 ma4
+䧟 xian4 xuan4
+䧠 shuan4
+䧤 pu2
+䧥 hui4
+䧦 wei2
+䧧 yi3
+䧨 ye4
+䧪 che4 zhe2
+䧫 hao2
+䧮 xian3 xian4
+䧯 chan2 zhan4
+䧰 hun4
+䧲 han4
+䧳 ci2 ci3
+䧵 qi2 shen3 zhen4
+䧶 kui2
+䧷 rou2
+䧺 xiong2
+䧼 hu2
+䧽 cui3
+䧿 que4
+䨀 di2 di4
+䨁 che4 wu4 yu4
+䨄 yan4
+䨅 liao2
+䨆 bi2 bi4 xu4
+䨋 nue4
+䨌 bao2 bo2
+䨍 ying3
+䨎 hong2
+䨏 ci2
+䨐 qia4 xia2
+䨑 ti2
+䨒 yu4
+䨓 lei2 lei4
+䨔 bao2
+䨖 ji4
+䨗 fu2
+䨘 xian4
+䨙 cen2 ya4 yin2
+䨛 se4
+䨞 yu3 yu4
+䨠 ai3
+䨡 han2
+䨢 dan4 di2 gao4 tan2
+䨣 ge2 geng4
+䨤 di2
+䨥 hu4 huo4
+䨦 pang2
+䨩 ling2
+䨪 mai2
+䨫 mai4 man4
+䨬 lian2
+䨮 xue3
+䨯 zhen4
+䨰 po4
+䨱 fu4
+䨲 nou2
+䨳 xi4
+䨴 dui4 weng4
+䨵 dan4
+䨶 yun3
+䨷 xian4
+䨸 yin3
+䨺 dui4 zhui4
+䨻 beng4
+䨼 hu4
+䨽 fei3
+䨾 fei3
+䨿 qian2 za2
+䩀 bei4
+䩃 shi4
+䩄 tian3
+䩅 zhan3
+䩆 jian3 zhan3
+䩈 hui4 wei4 xue3
+䩉 fu3
+䩊 wan3 wo4
+䩋 mo3
+䩌 qiao2
+䩍 liao3
+䩏 mie4
+䩐 ge2 ji2
+䩑 hong2
+䩒 yu2
+䩓 qi2
+䩔 duo4
+䩕 ang2
+䩗 ba4
+䩘 di4
+䩙 xuan4
+䩚 di4 dian4
+䩛 bi4
+䩜 zhou4
+䩝 pao2
+䩞 nian2 tian3 tie2 wei3
+䩟 yi2
+䩡 jia2
+䩢 da2 zhi4
+䩣 duo3 tu2 tui4
+䩤 xi4 xie2
+䩥 dan4
+䩦 tiao2 zuo4
+䩧 xie4
+䩨 chang4
+䩩 yuan3
+䩪 guan3
+䩫 liang3
+䩬 beng3 feng3
+䩮 lu4
+䩯 ji2
+䩰 xuan4
+䩱 shu4
+䩳 shu3 su4
+䩴 hu2
+䩵 yun4
+䩶 chan3
+䩸 rong2 rong3
+䩹 e2
+䩻 ba4
+䩼 feng2
+䩾 zhe4
+䩿 fen2
+䪀 guan3 ruan3
+䪁 bu3
+䪂 ge2
+䪄 huang2
+䪅 du2
+䪆 ti3
+䪇 bo2
+䪈 qian3 qian4
+䪉 la4 lie4
+䪊 long2
+䪋 wei4
+䪌 zhan4
+䪍 lan2 lan4
+䪏 na4 neng2
+䪐 bi4 pi4
+䪑 tuo2
+䪒 jiao4 zhi4 zhu4
+䪔 bu3
+䪕 ju2
+䪖 po4
+䪗 xia2
+䪘 wei3
+䪙 fu2 po4
+䪚 he4 ta4
+䪛 fan2
+䪜 chan4
+䪝 hu4
+䪞 za2
+䪤 fan2
+䪥 die2 xie4
+䪦 hong2
+䪧 chi2
+䪨 bao2 qu2
+䪩 yin2
+䪬 bo2 pu2
+䪭 ruan3
+䪮 chou3
+䪯 ying2
+䪱 gai3
+䪳 yun3
+䪴 zhen3
+䪵 ya3
+䪷 hou4
+䪸 min2
+䪹 pei2
+䪺 ge2
+䪻 bian4
+䪽 hao4
+䪾 mi2 zhen3
+䪿 sheng3 xin4
+䫀 gen3
+䫁 bi4
+䫂 duo3
+䫃 chun2
+䫄 chua4
+䫅 san4
+䫆 cheng2 zheng4
+䫇 ran2
+䫈 zen4
+䫉 mao4
+䫊 bo2 pei2
+䫋 tui2
+䫌 pi3
+䫍 fu3
+䫐 lin2
+䫒 men2
+䫓 wu2
+䫔 qi4 qie4 xi4
+䫕 zhi4
+䫖 chen3 hui3 nou4 shen4 ting2 ya4 zhu4
+䫗 xia2 xia4
+䫘 he2
+䫙 sang3
+䫛 hou2
+䫝 fu3 fu4
+䫞 rao2
+䫟 hun2 hun4
+䫠 pei2
+䫡 qian4 yan2
+䫣 xi2
+䫤 ming2
+䫥 kui3 wei3
+䫦 ge2 kai4
+䫨 ao4
+䫩 san3
+䫪 shuang3
+䫫 lou2 lou4
+䫬 zhen3
+䫭 hui4
+䫮 can2 can3 ti4
+䫰 lin4
+䫱 na2 ru2
+䫲 han4 kan3
+䫳 du2
+䫴 jin4
+䫵 mian2
+䫶 fan2
+䫷 e4
+䫸 nao2
+䫹 hong2
+䫺 hong2 hou4
+䫻 xue2 yu4
+䫼 xue4
+䫾 bi4
+䬀 you3
+䬁 yi2
+䬂 xue4 yue4
+䬃 sa4
+䬄 yu4
+䬅 li4 xie2
+䬆 li4
+䬇 yuan4
+䬈 dui4
+䬉 hao4
+䬊 qie4 sha4
+䬋 leng2
+䬎 guo2
+䬏 bu4 fou3
+䬐 wei3
+䬑 wei4
+䬓 an4 ang3
+䬔 xu4 yu2
+䬕 shang3
+䬖 heng2
+䬗 yang2
+䬙 yao2
+䬛 bi4 yu4
+䬝 heng2 hong4
+䬞 tao2
+䬟 liu2
+䬡 zhu4
+䬣 qi4
+䬤 chao2 zan4 zuo4
+䬥 yi4
+䬦 dou4
+䬧 yuan2
+䬨 cu4 jiu4 zu2
+䬪 bo2 fu4
+䬫 can3 ti2
+䬬 yang3
+䬮 yi2
+䬯 nian2
+䬰 shao4
+䬱 ben4
+䬳 ban3
+䬴 mo4
+䬵 ai4
+䬶 en4
+䬷 she3
+䬹 zhi4
+䬺 yang4
+䬻 jian4 kan3
+䬼 yuan4
+䬽 dui4
+䬾 ti2
+䬿 wei3 wei4
+䭀 xun4
+䭁 zhi4
+䭂 yi4
+䭃 ren3
+䭄 shi4
+䭅 hu2
+䭆 ne4
+䭇 yi4
+䭈 jian4
+䭉 sui3
+䭊 ying3
+䭋 bao3
+䭌 hu2
+䭍 hu2
+䭎 xie2 ye4
+䭐 yang4
+䭑 lian2
+䭓 en4
+䭕 jian4 zan3
+䭖 zhu4
+䭗 ying3
+䭘 yan4 ying3
+䭙 jin3
+䭚 chuang2 ne4
+䭛 dan4
+䭝 kuai4
+䭞 yi4
+䭟 ye4
+䭠 jian3 qian4
+䭡 en4
+䭢 ning2
+䭣 ci2
+䭤 qian3
+䭥 xue4 yang4 yao4 zhou4
+䭦 bo2
+䭧 mi3
+䭨 shui4
+䭩 mi4 mo2
+䭪 liang2
+䭫 qi3
+䭬 qi3
+䭭 shou3 shu2 shu4 tu4
+䭮 bi4 fu2
+䭯 bo2
+䭰 beng3 beng4
+䭱 bie2
+䭲 ni3 yi3
+䭳 wei4
+䭴 huan2 yuan4
+䭵 fan2
+䭶 qi2
+䭷 liu2 mao2
+䭸 fu4
+䭹 ang2
+䭺 ang2
+䭼 qi2
+䭽 qun2
+䭾 tuo2
+䭿 yi4
+䮀 bo2
+䮁 pian2
+䮂 bo2
+䮄 xuan2
+䮇 yu4
+䮈 chi2
+䮉 lu2 lv4
+䮊 yi2
+䮋 li4 lie4
+䮍 niao3 xing4
+䮎 xi4
+䮏 wu2
+䮑 lei4
+䮓 zhao4
+䮔 zui3
+䮕 chuo4
+䮗 an4 niu4 yan4
+䮘 er2 ni2 pai4 po2
+䮙 yu4
+䮚 leng4
+䮛 fu4
+䮜 sha4 zha2
+䮝 huan2 huan3 hun2
+䮞 chu4 chun3
+䮟 sou3
+䮡 bi4
+䮢 die2
+䮤 di2 he4
+䮥 li4
+䮧 han2 han4
+䮨 zai3
+䮩 gu2 gu3
+䮪 cheng2
+䮫 lou2 lv2
+䮬 mo4
+䮭 mi4
+䮮 mai4
+䮯 ao4
+䮰 dan3 dan4 zhe2
+䮱 zhu2
+䮲 huang2
+䮳 fan2
+䮴 deng4
+䮵 tong2 yong3
+䮷 du2
+䮸 hu2 mu2 wo4
+䮹 wei4
+䮺 ji4
+䮻 chi4 dao3 dao4 dei3
+䮼 lin2
+䮾 pang2
+䮿 jian3
+䯀 nie4
+䯁 luo2
+䯂 ji2
+䯅 nie4
+䯆 yi4
+䯈 wan2
+䯉 ya4
+䯊 qia4
+䯋 bo2
+䯍 ling2
+䯎 gan4
+䯏 huo2
+䯐 hai2
+䯒 heng2
+䯓 kui2
+䯔 cen2 ze2
+䯖 lang2
+䯗 bi4
+䯘 huan4
+䯙 po4
+䯚 ou3 yao3
+䯛 jian3 wan4
+䯜 ti4
+䯝 sui3
+䯟 dui4 xia2
+䯠 ao3 ao4
+䯡 jian3 jian4 qian4
+䯢 mo2
+䯣 gui4 kui4
+䯤 kuai4
+䯥 an4 qi4
+䯦 ma4
+䯧 qing3
+䯨 fen2 he4
+䯪 kao3
+䯫 hao4 sha4
+䯬 duo3
+䯮 nai2
+䯰 jie4
+䯱 fu4
+䯲 pa2
+䯴 chang2
+䯵 nie4
+䯶 man2
+䯸 ci4
+䯺 kuo4
+䯼 di2
+䯽 fu3 pou2
+䯾 tiao2
+䯿 zu2 zuo2
+䰀 wo3
+䰁 fei4
+䰂 cai4
+䰃 peng2
+䰄 shi4
+䰆 rou2
+䰇 qi2
+䰈 cha3 cuo2
+䰉 pan2 pan4
+䰊 bo2
+䰋 man2
+䰌 zong3
+䰍 ci4 qi1
+䰎 gui4 hui3 kui4
+䰏 ji4
+䰐 lan2
+䰒 meng2
+䰓 mian2
+䰔 pan2
+䰕 lu2
+䰖 cuan2
+䰘 liu2
+䰙 yi3
+䰚 wen2
+䰛 li4
+䰜 li4
+䰝 zeng4
+䰞 zhu3
+䰟 hun2
+䰠 shen2
+䰡 chi4
+䰢 xing4
+䰣 wang3
+䰥 huo4 ji4 she4 yu4
+䰦 pi3 pi4
+䰨 mei4
+䰩 che3 chi3
+䰪 mei4
+䰫 chao2
+䰬 ju2
+䰭 nou4 ru2
+䰯 ni3 ran2 yi4
+䰰 ru2
+䰱 ling2
+䰲 ya4
+䰴 qi4 zhi4
+䰷 bang4 bo2
+䰹 ze2
+䰺 jie4
+䰻 yu2
+䰼 xin2
+䰽 bei4
+䰾 ba4
+䰿 tuo2
+䱁 qiao2
+䱂 you3
+䱃 di3 zhi4
+䱄 jie4
+䱅 mo4
+䱆 sheng2
+䱇 shan4 tao2
+䱈 qi2 yi4
+䱉 shan4
+䱊 mi3
+䱋 dan3 gong3
+䱌 yi2
+䱍 geng4
+䱎 geng4
+䱏 tou3
+䱑 xue2
+䱒 yi4
+䱓 ting2
+䱔 tiao2
+䱕 mou2
+䱖 liu2 liu3
+䱘 li2
+䱚 lu4
+䱛 xu4
+䱜 cuo4 que4
+䱝 ba4 pai2
+䱞 liu2 nai4 wei3
+䱟 ju4
+䱠 zhan4
+䱡 ju2
+䱣 zu2
+䱤 xian4
+䱥 zhi2 zhi4
+䱨 zhi4
+䱫 la4
+䱭 geng4
+䱮 e2
+䱯 mu2
+䱰 zhong4
+䱱 di4 ti2
+䱲 yan2
+䱴 geng4
+䱶 lang2
+䱷 yu2
+䱹 na4 zha3
+䱺 hai2
+䱻 hua2
+䱼 zhan3
+䱾 lou2 yu2
+䱿 chan4
+䲀 die2 sui4 zhi4 zou4
+䲁 wei4
+䲂 xuan2
+䲃 zao3
+䲄 min2 min3
+䲊 tuo3
+䲋 cen2
+䲌 kuan3
+䲍 teng2
+䲎 nei3
+䲏 lao2
+䲐 lu3
+䲑 yi2
+䲒 xie4
+䲓 yan3
+䲔 qing2 qing4
+䲕 pu3 pu4
+䲖 chou2
+䲗 xian2
+䲘 guan3 kang4 wei2
+䲙 jie2
+䲚 lai4 lan4
+䲛 meng2
+䲜 ye4
+䲞 li4 luo3
+䲟 yin4
+䲢 teng2
+䲣 yu2
+䲦 cha2 dai4 di4 tuo3
+䲧 du4 shui4
+䲨 hong2
+䲪 xi4
+䲬 qi2
+䲮 yuan2
+䲯 ji2
+䲰 yun4
+䲱 fang3
+䲳 hang2
+䲴 zhen4
+䲵 hu4 que4
+䲸 jie4
+䲹 pei2
+䲺 gan4
+䲻 xuan2 yuan2
+䲽 dao3 shi2
+䲾 qiao3
+䲿 ci2
+䳀 die2
+䳁 ba2 bin3 bo2 yuan2
+䳂 tiao2
+䳃 wan3
+䳄 ci2
+䳅 zhi3
+䳆 bai2
+䳇 wu3
+䳈 bao3
+䳉 dan4
+䳊 ba2
+䳋 tong2 zhong4
+䳎 jiu4
+䳏 gui4
+䳐 ci4
+䳑 you3 yu4
+䳒 yuan2
+䳓 lao3
+䳔 jiu4 ju2
+䳕 fou2
+䳖 nei4 ye4
+䳗 e2
+䳘 e2
+䳙 xing3
+䳚 he2 kan3
+䳛 yan4
+䳜 tu2
+䳝 bu4 diao4 fu3 pou3
+䳞 beng3
+䳟 kou4 ming2 mo3
+䳠 chui2 rui4 zhu4
+䳢 qi2
+䳣 yuan2
+䳧 hou2
+䳨 huang2
+䳪 juan4 tuan2
+䳫 kui2
+䳬 e4 yao3 yi4
+䳭 ji2
+䳮 mo4
+䳯 chong2 chong3
+䳰 bao3
+䳱 wu4
+䳲 zhen4
+䳳 xu4
+䳴 da2 ta4
+䳵 chi4
+䳷 cong2
+䳸 ma2 mai2
+䳹 kou4
+䳺 yan4
+䳻 can2 chan2 die2 zhan4
+䳽 he4
+䳿 lan2 ran2
+䴀 tong2
+䴁 yu4
+䴂 hang4 xiang4
+䴃 nao2
+䴄 li4 shun4
+䴅 fen2
+䴆 pu2
+䴇 ling2
+䴈 ao3
+䴉 xuan2
+䴊 yi2
+䴋 xuan2
+䴌 meng2
+䴎 lei3
+䴏 yan4
+䴐 bao3
+䴑 die2
+䴒 ling2
+䴓 shi1
+䴔 jiao1
+䴕 lie4
+䴖 jing1
+䴗 ju2
+䴘 ti1
+䴙 pi4
+䴚 gang3
+䴛 jiao3 tu2 xi4 xiao4 yin2
+䴜 huai2
+䴝 bu4 chuai4
+䴞 di2
+䴟 huan2 huan4
+䴠 yao3
+䴡 li4
+䴢 mi2
+䴦 ren2 yin2
+䴩 piao2
+䴪 lu4
+䴫 ling2
+䴬 yi4
+䴭 cai2
+䴮 shan4
+䴰 shu2
+䴱 tuo2
+䴲 mo4
+䴳 he4 hua2
+䴴 tie4
+䴵 bing3 zhuo2
+䴶 peng2
+䴷 hun2
+䴹 guo3
+䴺 bu4 cai3 chan4
+䴻 li2
+䴼 chan3 chan4
+䴽 bai4 pi2
+䴾 cuo2 cuo4 ye4 zhen3 zi3
+䴿 meng2
+䵀 suo3
+䵁 qiang4
+䵂 zhi2
+䵃 kuang4
+䵄 bi2 bo2 feng4 peng3
+䵅 ao2
+䵆 meng2
+䵇 xian4
+䵉 tou2
+䵋 wei3
+䵏 lao3
+䵐 chan3 chan4
+䵑 ni4
+䵒 ni4
+䵓 li2
+䵔 dong3
+䵕 ju4
+䵖 jian4 qian4 xian4
+䵗 fu2
+䵘 sha4 shai4
+䵙 zha3
+䵚 tao3
+䵛 jian4 xian4
+䵜 nong3
+䵝 ya4 yi4
+䵞 jing4 qing2
+䵟 gan3
+䵠 di2
+䵡 jian3
+䵢 mei4 wei4
+䵣 da2 zhan3
+䵤 jian3
+䵥 she4 wan2 ying4 yu4
+䵦 xie4
+䵧 zai4
+䵨 mang2
+䵩 li2
+䵪 gun4
+䵫 yu4
+䵬 ta4
+䵭 zhe4
+䵮 yang4
+䵯 tuan3
+䵱 he4 xi4
+䵲 diao4
+䵳 wei4
+䵴 yun4 zeng4
+䵵 zha2 zhuo2
+䵶 qu2
+䵺 ting3
+䵻 gu3 hu2 hui4
+䵽 ca4
+䵾 fu2
+䵿 tie4
+䶀 ta4
+䶁 ta4
+䶂 zhuo2
+䶃 han2
+䶄 ping2
+䶅 he2
+䶇 zhou4
+䶈 bo2
+䶉 liu2
+䶊 nv4
+䶌 pao4
+䶍 di4 ti4
+䶎 sha4
+䶏 ti3 ti4
+䶐 kuai4
+䶑 ti4
+䶒 qi2
+䶓 ji4 qi4
+䶔 chi2 min2
+䶕 pa2
+䶖 jin4 qin2
+䶗 ke4 qia3 qie4
+䶘 li4
+䶙 ju4
+䶚 qu3
+䶛 la4 lie4
+䶜 gu4
+䶝 qia4 xia2
+䶞 qi2
+䶟 xian4
+䶠 jian3 xian2
+䶡 shi2 ze2 zhi4
+䶢 xian2
+䶣 ai2
+䶤 hua2
+䶥 ju3
+䶦 ze2
+䶧 yao3
+䶩 ji4
+䶪 cha2
+䶫 kan3 yan2 yan4
+䶮 yan2 yan3
+䶱 tong2
+䶲 nan2 nan4 ran2
+䶳 yue4
+䶵 chi2 shi3
+一 yi1
+丁 ding1 zheng1
+丂 kao3 qiao3 yu2
+七 qi1
+丄 shang4 shang3
+丅 xia4
+万 wan4 mo4
+丈 zhang4
+三 san1 san4
+上 shang4
+下 xia4
+丌 ji1
+不 bu4 fou3 fou1
+与 yu3 yu4 yu2
+丏 mian3
+丐 gai4
+丑 chou3
+丒 chou3
+专 zhuan1
+且 qie3 ju1
+丕 pi1
+世 shi4
+丗 shi4
+丘 qiu1
+丙 bing3
+业 ye4
+丛 cong2
+东 dong1
+丝 si1
+丞 cheng2
+丟 diu1
+丠 qiu1
+両 liang3 liang4
+丢 diu1
+丣 you3
+两 liang3 liang4
+严 yan2
+並 bing4 bang4
+丧 sang1 sang4
+丨 gun3
+丩 jiu1
+个 ge4 ge3
+丫 ya1
+丬 qiang2
+中 zhong1 zhong4
+丮 ji3
+丯 jie4
+丰 feng1
+丱 guan4
+串 chuan4 guan4
+丳 chan3
+临 lin2 lin4
+丵 zhuo3
+丶 zhu3
+丸 wan2
+丹 dan1
+为 wei4 wei2
+主 zhu3
+丼 jing3
+丽 li4 li2
+举 ju3
+丿 pie3
+乀 fu2
+乁 yi2
+乂 yi4
+乃 nai3
+久 jiu3
+乆 jiu3
+乇 zhe2 nue4 zhe4 tuo1
+么 yao1 mo5 me5 ma5 mo3
+义 yi4
+之 zhi1
+乌 wu1 wu4
+乍 zha4 zuo4
+乎 hu1 hu2
+乏 fa2
+乐 le4 yue4 yao4 luo4 liao2
+乑 zhong4
+乒 ping1
+乓 pang1 pang5
+乔 qiao2
+乕 hu3
+乖 guai1
+乗 cheng2 sheng4
+乘 cheng2 sheng4
+乙 yi3
+乚 yin3
+乜 mie1 nie4
+九 jiu3
+乞 qi3
+也 ye3
+习 xi2
+乡 xiang1 xiang3 xiang4
+乢 gai4
+乣 jiu3
+书 shu1
+乨 shi3
+乩 ji1
+乪 nang2
+乫 jia1
+乭 shi2
+买 mai3
+乱 luan4
+乳 ru3
+乴 xue2
+乵 yan3
+乶 fu3
+乷 sha1
+乸 na3
+乹 gan1 qian2
+乾 gan1 qian2
+乿 chi4
+亀 gui1
+亁 gan1
+亂 luan4
+亃 lin2
+亄 yi4
+亅 jue2
+了 le5 liao3
+予 yu2 yu3
+争 zheng1 zheng4
+亊 shi4
+事 shi4
+二 er4
+亍 chu4
+于 yu2 xu1
+亏 kui1 yu2
+亐 yu2
+云 yun2
+互 hu4
+亓 qi2
+五 wu3
+井 jing3
+亖 si4
+亗 sui4
+亘 gen4 geng4
+亙 gen4 geng4
+亚 ya4 ya1
+些 xie1 suo4 sa1
+亜 ya4
+亝 qi2 zhai1 zi1
+亞 ya4 ya1
+亟 ji2 qi4
+亠 tou2
+亡 wang2 wu2
+亢 kang4 gang1
+亣 ta4
+交 jiao1
+亥 hai4
+亦 yi4
+产 chan3
+亨 heng1 xiang3 peng1
+亩 mu3
+享 xiang3
+京 jing1
+亭 ting2
+亮 liang4
+亯 xiang3
+亰 jing1
+亱 ye4
+亲 qin1 xin1 qing4
+亳 bo2
+亴 you4
+亵 xie4
+亶 dan3 dan4
+亷 lian2
+亸 duo3
+亹 wei3 men2
+人 ren2
+亻 ren2
+亼 ji2
+亾 wang2 wu2
+亿 yi4
+什 shi2 shen2
+仁 ren2
+仂 le4
+仃 ding1
+仄 ze4
+仅 jin3 jin4
+仆 pu1 fu4 pu2
+仇 chou2 qiu2
+仈 ba1
+仉 zhang3
+今 jin1
+介 jie4
+仌 bing1
+仍 reng2
+从 cong2 zong4 zong1 cong1
+仏 fo2
+仐 san3
+仑 lun2
+仓 cang1
+仔 zi3 zai3
+仕 shi4
+他 ta1
+仗 zhang4
+付 fu4
+仙 xian1
+仚 xian1
+仛 tuo1
+仜 hong2
+仝 tong2 tong4
+仞 ren4
+仟 qian1
+仠 gan2
+仡 yi4 ge1
+仢 di2
+代 dai4
+令 ling4 ling2 ling3
+以 yi3
+仦 chao4
+仧 chang2 zhang3
+仨 sa1
+仪 yi2
+仫 mu4
+们 men5
+仭 ren4
+仮 jia3 fan3
+仯 chao4
+仰 yang3 yang4 ang2
+仱 qian2
+仲 zhong4
+仳 pi3 pi2
+仴 wan4
+仵 wu3
+件 jian4
+价 jia4 jie4 jie5
+仸 yao3
+仹 feng1
+仺 cang1
+任 ren4 ren2
+仼 wang2
+份 fen4 bin1
+仾 di1
+仿 fang3 pang2
+伀 zhong1
+企 qi3
+伂 pei4
+伃 yu2
+伄 diao4
+伅 dun4
+伆 wen4
+伇 yi4
+伈 xin3
+伉 kang4
+伊 yi1
+伋 ji2
+伌 ai4
+伍 wu3
+伎 ji4 qi2
+伏 fu2
+伐 fa2
+休 xiu1
+伒 jin4
+伓 bei1
+伔 dan3 shen3
+伕 fu1
+伖 tang3
+众 zhong4
+优 you1
+伙 huo3 huo5
+会 hui4 kuai4 gui4
+伛 yu3
+伜 cui4
+伝 chuan2 yun2
+伞 san3
+伟 wei3
+传 chuan2 zhuan4
+伡 che1
+伢 ya2
+伣 xian4
+伤 shang1
+伥 chang1
+伦 lun2
+伧 cang1 cheng2
+伨 xun4
+伩 xin4
+伪 wei3 wei4
+伫 zhu4
+伭 xuan2
+伮 nu2
+伯 bo2 bai3 ba4
+估 gu1 gu3 gu4
+伱 ni3
+伲 ni3 ni4
+伳 xie4
+伴 ban4 pan4
+伵 xu4
+伶 ling2
+伷 zhou4
+伸 shen1
+伹 qu1
+伺 si4 ci4
+伻 beng1
+似 si4 shi4
+伽 qie2 jia1
+伾 pi1
+伿 yi4
+佀 si4 shi4
+佁 ai3 yi3 chi4 si4
+佂 zheng1
+佃 dian4 tian2
+佄 han2
+佅 mai4
+但 dan4
+佇 zhu4
+佈 bu4
+佉 qu1
+佊 bi3
+佋 shao4
+佌 ci3
+位 wei4
+低 di1
+住 zhu4
+佐 zuo3
+佑 you4
+佒 yang1
+体 ti3 ben4 ti1
+佔 zhan4
+何 he2 he4
+佖 bi4
+佗 tuo2 tuo1 tuo4 yi2
+佘 she2
+余 yu2 xu2
+佚 yi4 die2
+佛 fo2 fu2
+作 zuo4 zuo1 zuo2
+佝 kou4 gou1
+佞 ning4
+佟 tong2
+你 ni3
+佡 xuan1
+佢 qu2
+佣 yong4 yong1 yong2
+佤 wa3
+佥 qian1
+佧 ka3
+佩 pei4
+佪 hui2 huai2
+佫 he4
+佬 lao3
+佭 xiang2
+佮 ge2
+佯 yang2
+佰 bai3 bo2
+佱 fa3
+佲 ming2
+佳 jia1 jia5
+佴 er4 nai4 mi3
+併 bing4
+佶 ji2
+佷 hen3
+佸 huo2
+佹 gui3
+佺 quan2
+佻 tiao1
+佼 jiao3 jiao1
+佽 ci4
+佾 yi4
+使 shi3 shi4
+侀 xing2
+侁 shen1
+侂 tuo1
+侃 kan3
+侄 zhi2
+侅 gai1
+來 lai2 lai4
+侇 yi2
+侈 chi3
+侉 kua1 kua3
+侊 guang1
+例 li4
+侌 yin1
+侍 shi4
+侎 mi3 mei3
+侏 zhu1
+侐 xu4
+侑 you4
+侒 an1
+侓 lu4
+侔 mou2
+侕 er2
+侖 lun2
+侗 tong1 tong2 tong3 dong4
+侘 cha4
+侙 chi4
+侚 xun4
+供 gong1 gong4
+侜 zhou1
+依 yi1 yi3
+侞 ru3
+侟 jian4
+侠 xia2
+価 si4
+侢 zai4
+侣 lv3
+侥 jiao3
+侦 zhen1 zheng1
+侧 ce4 ze4
+侨 qiao2
+侩 kuai4
+侪 chai2
+侫 ning4
+侬 nong2
+侭 jin3
+侮 wu3
+侯 hou2 hou4
+侰 jiong3
+侱 cheng3
+侲 zhen4
+侳 zuo4 cuo4
+侴 chou3
+侵 qin1
+侶 lv3
+侷 ju2
+侸 shu4
+侹 ting3
+侺 shen4
+侻 tuo1
+侼 bo2
+侽 nan2
+侾 hao1
+便 bian4 pian2
+俀 tui3
+俁 yu3
+係 xi4
+促 cu4
+俄 e2
+俅 qiu2
+俆 xu2 shu1
+俇 kuang3 kuang1 guang4
+俈 ku4
+俉 wu4
+俊 jun4
+俋 yi4
+俌 fu3
+俍 lang2
+俎 zu3
+俏 qiao4
+俐 li4
+俑 yong3
+俒 hun4
+俓 jing4
+俔 xian4
+俕 san4
+俖 pai3
+俗 su2
+俘 fu2
+俙 xi1
+俚 li3
+俛 fu3 mian3
+俜 ping1
+保 bao3
+俞 yu2 shu4
+俟 si4 qi2
+俠 xia2
+信 xin4 shen1
+俢 xiu1
+俣 yu3
+俤 ti4
+俥 che1
+俦 chou2
+俨 yan3
+俩 lia3 liang3
+俪 li4
+俫 lai2 lai4
+俭 jian3
+修 xiu1
+俯 fu3
+俰 he4
+俱 ju4
+俲 xiao4
+俳 pai2
+俴 jian4
+俵 biao4
+俶 chu4 ti4
+俷 fei4
+俸 feng4
+俹 ya4
+俺 an3
+俻 bei4
+俼 yu4
+俽 xin1
+俾 bi3
+俿 jian4
+倀 chang1
+倁 chi2
+倂 bing4
+倃 zan2 za2
+倄 yao2
+倅 cui4
+倆 lia3 liang3
+倇 wan3
+倈 lai2 lai4
+倉 cang1
+倊 zong4
+個 ge4 ge3
+倌 guan1
+倍 bei4
+倎 tian1
+倏 shu1
+倐 shu1
+們 men5
+倒 dao3 dao4
+倓 tan2
+倔 jue2 jue4
+倕 chui2
+倖 xing4
+倗 peng2
+倘 tang3 chang2
+候 hou4
+倚 yi3
+倛 qi1
+倜 ti4
+倝 gan4
+倞 jing4 liang4
+借 jie4
+倠 sui1
+倡 chang4 chang1
+倢 jie2
+倣 fang3 pang2
+値 zhi2
+倥 kong1 kong3
+倦 juan4
+倧 zong1
+倨 ju4
+倩 qian4 qing4
+倪 ni2 ni4
+倫 lun2
+倬 zhuo1
+倭 wei1 wo1 wo3
+倮 luo3
+倯 song1
+倰 leng2 leng4 ling2
+倱 hun4
+倲 dong1
+倳 zi4
+倴 ben4
+倵 wu3
+倶 ju4 ju1
+倷 nai4
+倸 cai3
+倹 jian3
+债 zhai4
+倻 ye1
+值 zhi2 zhi4
+倽 sha4
+倾 qing1
+偀 ying1
+偁 cheng1
+偂 jian1
+偃 yan3
+偄 nuan4
+偅 zhong4
+偆 chun3
+假 jia3 jia4 xia2
+偈 jie2 qi4 ji4
+偉 wei3
+偊 yu3 ju3
+偋 bing3
+偌 ruo4
+偍 ti2
+偎 wei1
+偏 pian1
+偐 yan4
+偑 feng1
+偒 tang3 dang4
+偓 wo4
+偔 e4
+偕 xie2 jie1
+偖 che3
+偗 sheng3
+偘 kan3
+偙 di4
+做 zuo4
+偛 cha1
+停 ting2
+偝 bei4
+偞 ye4
+偟 huang2
+偠 yao3
+偡 zhan4
+偢 chou3
+偣 yan1
+偤 you3
+健 jian4
+偦 xu1
+偧 zha1
+偨 ci1
+偩 fu4
+偪 bi1
+偫 zhi4
+偬 zong3
+偭 mian3
+偮 ji2
+偯 yi3
+偰 xie4
+偱 xun2
+偲 si1
+偳 duan1
+側 ce4 ze4
+偵 zhen1 zheng1
+偶 ou3
+偷 tou1
+偸 tou1
+偹 bei4
+偺 za2 zan2
+偻 lv3 lou2
+偼 jie2
+偽 wei3 wei4
+偾 fen4
+偿 chang2
+傀 gui1 kui3
+傁 sou3
+傂 zhi4
+傃 su4
+傄 xia1
+傅 fu4 fu1
+傆 yuan4
+傇 rong3
+傈 li4
+傉 ru4
+傊 yun3
+傋 gou4
+傌 ma4
+傍 bang4 pang2
+傎 dian1
+傏 tang2
+傐 hao4
+傑 jie2
+傒 xi1 xi2 xi4
+傓 shan4
+傔 qian4
+傕 jue2
+傖 cang1 cheng2
+傗 chu4
+傘 san3
+備 bei4
+傚 xiao4
+傛 yong3 rong2
+傜 yao2
+傝 tan4 ta4
+傞 suo1
+傟 yang3
+傠 fa1
+傡 bing4
+傢 jia1
+傣 dai3
+傤 zai4
+傥 tang3
+傧 bin4
+储 chu3 chu2
+傩 nuo2
+傪 can1
+傫 lei3
+催 cui1
+傭 yong1 yong2
+傮 zao1 cao2
+傯 zong3
+傰 peng2
+傱 song3
+傲 ao4
+傳 chuan2 zhuan4
+傴 yu3
+債 zhai4
+傶 cou4
+傷 shang1
+傸 qiang3
+傹 jing4 jiang1
+傺 chi4
+傻 sha3
+傼 han4
+傽 zhang1
+傾 qing1
+傿 yan4
+僀 di4
+僁 xi1
+僂 lv3 lou2
+僃 bei4
+僄 piao4
+僅 jin3 jin4
+僆 lian2 lian3 lian4
+僇 lu4
+僈 man4
+僉 qian1
+僊 xian1
+僋 tan4
+僌 ying2
+働 dong4
+僎 zhuan4
+像 xiang4
+僐 shan4
+僑 qiao2
+僒 jiong3
+僓 tui3 tui2
+僔 zun3
+僕 pu2
+僖 xi1
+僗 lao2
+僘 chang3
+僙 guang1
+僚 liao2
+僛 qi1
+僜 deng4
+僝 chan2
+僞 wei3 wei4
+僟 ji1
+僠 fan1
+僡 hui4
+僢 chuan3
+僣 jian4
+僤 dan4
+僥 jiao3
+僦 jiu4
+僧 seng1
+僨 fen4
+僩 xian4
+僪 jue2
+僫 e4
+僬 jiao1 jiao4
+僭 jian4
+僮 tong2 zhuang4
+僯 lin3
+僰 bo2
+僱 gu4
+僳 su4
+僴 xian4
+僵 jiang1
+僶 min3
+僷 ye4
+僸 jin4
+價 jia4 jie5
+僺 qiao4
+僻 pi4
+僼 feng1
+僽 zhou4
+僾 ai4
+僿 sai4
+儀 yi2
+儁 jun4
+儂 nong2
+儃 chan2 tan3
+億 yi4
+儅 dang1 dang4
+儆 jing3
+儇 xuan1
+儈 kuai4
+儉 jian3
+儊 chu4
+儋 dan1
+儌 jiao3 yao2
+儍 sha3
+儎 zai4
+儐 bin4 bin1
+儑 an4 e4
+儒 ru2
+儓 tai2
+儔 chou2
+儕 chai2
+儖 lan2
+儗 ni3
+儘 jin3
+儙 qian4
+儚 meng2
+儛 wu3
+儜 ning2
+儝 qiong2
+儞 ni3 er3 nai3
+償 chang2
+儠 lie4
+儡 lei3
+儢 lv3
+儣 kuang4
+儤 bao4
+儥 du2
+儦 biao1
+儧 zan3
+儨 zhi2
+儩 si4
+優 you1
+儫 hao2
+儬 chen4
+儭 chen4
+儮 li4
+儯 teng2
+儰 wei3
+儱 long3
+儲 chu3 chu2
+儳 chan4
+儴 rang2
+儵 shu1
+儶 hui4
+儷 li4
+儸 luo2
+儹 zan3
+儺 nuo2
+儻 tang3
+儼 yan3
+儽 lei3
+儾 nang4
+儿 er2 er5
+兀 wu4
+允 yun3
+兂 zan1 zan3
+元 yuan2
+兄 xiong1
+充 chong1
+兆 zhao4
+兇 xiong1
+先 xian1
+光 guang1
+兊 dui4
+克 ke4
+兌 dui4
+免 mian3
+兎 tu4
+兏 chang2
+児 er2
+兑 dui4 yue4 rui4
+兒 er2 er5
+兓 xin1
+兔 tu4
+兕 si4
+兖 yan3
+兗 yan3
+兘 shi3
+党 dang3
+兛 qian1
+兜 dou1
+兝 fen1
+兞 mao2
+兟 shen1
+兠 dou1
+兢 jing1
+兣 li3 ke4
+兤 huang2
+入 ru4
+兦 wang2
+內 nei4 na4
+全 quan2
+兩 liang3 liang4
+兪 yu2 shu4
+八 ba1
+公 gong1
+六 liu4 lu4
+兮 xi1
+兰 lan2
+共 gong4 gong1
+兲 tian1
+关 guan1 wan1
+兴 xing1 xing4
+兵 bing1
+其 qi2 ji1
+具 ju4
+典 dian3
+兹 zi1 ci2
+养 yang3 yang4
+兼 jian1
+兽 shou4
+兾 ji4
+兿 yi4
+冀 ji4
+冁 chan3
+冂 jiong1
+冄 ran3
+内 nei4
+冇 mao3
+冈 gang1
+冉 ran3
+冊 ce4
+冋 jiong1
+册 ce4
+再 zai4
+冎 gua3
+冏 jiong3
+冐 mao4 mo4
+冑 zhou4
+冒 mao4 mou4 mo4
+冓 gou4 gou1
+冔 xu3
+冕 mian3
+冖 mi4
+冗 rong3
+冘 yin2 you2
+写 xie3
+冚 kan3
+军 jun1
+农 nong2
+冝 yi2
+冞 mi2
+冟 shi4
+冠 guan1 guan4
+冡 meng2
+冢 zhong3
+冣 ju4
+冤 yuan1
+冥 ming2
+冦 kou4
+冨 fu4
+冩 xie3
+冪 mi4
+冫 bing1
+冬 dong1
+冭 tai2
+冮 gang1
+冯 feng2 ping2
+冰 bing1 ning2
+冱 hu4
+冲 chong1
+决 jue2
+冴 hu4
+况 kuang4
+冶 ye3
+冷 leng3
+冸 pan4
+冹 fu2
+冺 min3
+冻 dong4
+冼 xian3
+冽 lie4
+冾 xia2
+冿 jian1
+净 jing4
+凁 shu4
+凂 mei3
+凃 tu2
+凄 qi1
+凅 gu4 he2
+准 zhun3
+凇 song1 song4
+凈 jing4
+凉 liang2 liang4
+凊 qing4
+凋 diao1
+凌 ling2
+凍 dong4
+凎 gan4
+减 jian3
+凐 yin1
+凑 cou4
+凒 yi2
+凓 li4
+凔 cang1
+凕 ming3
+凗 cui2
+凘 si1
+凙 duo2
+凚 jin4
+凛 lin3
+凜 lin3
+凝 ning2
+凞 xi1
+凟 du2
+几 ji1 ji3
+凡 fan2
+凢 fan2
+凣 fan2
+凤 feng4
+凥 ju1
+処 chu3 chu4 ju4
+凨 feng1 feng3 feng4
+凫 fu2
+凬 feng1
+凭 ping2
+凮 feng1
+凯 kai3
+凰 huang2
+凱 kai3
+凲 gan1
+凳 deng4
+凴 ping2
+凵 qu1
+凶 xiong1
+凷 kuai4
+凸 tu1
+凹 ao1 wa1
+出 chu1
+击 ji2 ji1
+凼 dang4
+函 han2
+凾 han2
+凿 zao2 zuo4
+刀 dao1
+刁 diao1
+刂 dao1
+刃 ren4
+刄 ren4
+刅 chuang1
+分 fen1 fen4
+切 qie1 qie4 qi4
+刈 yi4
+刉 ji1
+刊 kan1
+刋 qian4 kan1
+刌 cun3
+刍 chu2
+刎 wen3
+刏 ji1
+刐 dan3
+刑 xing2
+划 hua2 hua4
+刓 wan2
+刔 jue2
+刕 li2
+刖 yue4
+列 lie4
+刘 liu2
+则 ze2
+刚 gang1
+创 chuang4 chuang1
+刜 fu2
+初 chu1
+刞 qu4
+刟 ju1
+删 shan1
+刡 min3
+刢 ling2
+刣 zhong1
+判 pan4
+別 bie2
+刦 jie2
+刧 jie2
+刨 pao2 bao4
+利 li4
+刪 shan1
+别 bie2 bie4
+刬 chan3
+刭 jing3
+刮 gua1
+刯 gen1
+到 dao4
+刱 chuang4 chuang1
+刲 kui1
+刳 ku1
+刴 duo4
+刵 er4
+制 zhi4
+刷 shua1 shua4
+券 quan4
+刹 sha1 cha4
+刺 ci4 qi4
+刻 ke4
+刼 jie2
+刽 gui4
+刾 ci4 qi4
+刿 gui4
+剀 kai3
+剁 duo4
+剂 ji4
+剃 ti4
+剄 jing3
+剅 lou2
+剆 gen1
+則 ze2
+剈 yuan1
+剉 cuo4
+削 xue1 xiao1
+剋 ke4
+剌 la4 la2
+前 qian2
+剎 sha1 cha4
+剏 chuang4 chuang1
+剐 gua3
+剑 jian4
+剒 cuo4
+剓 li2
+剔 ti1
+剕 fei4
+剖 pou1
+剗 chan3
+剘 qi2
+剙 chuang4 chuang1
+剚 zi4
+剛 gang1
+剜 wan1
+剝 bo1 bao1
+剞 ji1
+剟 duo1
+剠 qing2 lve4
+剡 yan3 shan4
+剢 zhuo2
+剣 jian4
+剤 ji4
+剥 bo1 bao1 pu1
+剦 yan1
+剧 ju4
+剨 huo4
+剩 sheng4
+剪 jian3
+剫 duo2
+剬 duan1 tuan2 zhi4
+剭 wu1
+剮 gua3
+副 fu4
+剰 sheng4
+剱 jian4
+割 ge1
+剳 zha1
+剴 kai3
+創 chuang4 chuang1
+剶 juan1
+剷 chan3
+剸 tuan2 zhuan1
+剹 lu4
+剺 li2
+剻 fou2
+剼 shan1
+剽 piao4 piao1 piao2 biao3 biao1
+剾 kou1
+剿 jiao3 chao1
+劀 gua1
+劁 qiao1
+劂 jue2
+劃 hua4 hua2
+劄 zha2 da2
+劅 zhuo4
+劆 lian2
+劇 ju4
+劈 pi1 pi3
+劉 liu2
+劊 gui4
+劋 jiao3
+劌 gui4
+劍 jian4
+劎 jian4
+劏 tang1
+劐 huo1
+劑 ji4
+劒 jian4
+劓 yi4
+劔 jian4
+劕 zhi2
+劖 chan2
+劗 cuan2 jian3
+劘 mo2
+劙 li2
+劚 zhu2
+力 li4
+劜 ya1
+劝 quan4
+办 ban4
+功 gong1
+加 jia1
+务 wu4
+劢 mai4
+劣 lie4
+劤 jin4
+劥 keng1
+劦 xie2
+劧 zhi3
+动 dong4
+助 zhu4
+努 nu3
+劫 jie2
+劬 qu2
+劭 shao4
+劮 yi4
+劯 zhu1
+劰 miao3
+励 li4
+劲 jing4 jin4
+劳 lao2 lao4
+労 lao2
+劵 juan4 quan4
+劶 kou3
+劷 yang2
+劸 wa1
+効 xiao4
+劺 mou2
+劻 kuang1
+劼 jie2
+劽 lie4
+劾 he2
+势 shi4
+勀 ke4
+勁 jin4 jing4
+勂 hao2
+勃 bo2
+勄 min3
+勅 chi4
+勆 lang2
+勇 yong3
+勈 yong3
+勉 mian3
+勊 ke4
+勋 xun1
+勌 juan4
+勍 qing2
+勎 lu4
+勏 pou3
+勐 meng3
+勑 lai4 chi4
+勒 le4 lei1
+勓 kai4
+勔 mian3
+動 dong4
+勖 xu4
+勗 xu4
+勘 kan1 kan4
+務 wu4
+勚 yi4
+勛 xun1
+勜 weng3
+勝 sheng4 sheng1
+勞 lao2 lao4
+募 mu4
+勠 lu4
+勡 piao4
+勢 shi4
+勣 ji1
+勤 qin2
+勥 qiang3 jiang4
+勦 jiao3 chao1
+勧 quan4
+勨 yang3
+勩 yi4
+勪 jue2
+勫 fan2
+勬 juan4
+勭 tong2
+勮 ju4
+勯 dan1
+勰 xie2
+勱 mai4
+勲 xun1
+勳 xun1
+勴 lv4
+勵 li4
+勶 che4
+勷 rang2 xiang1
+勸 quan4
+勹 bao1
+勺 shao2 zhuo2
+勻 yun2
+勼 jiu1
+勽 bao4
+勾 gou1 gou4
+勿 wu4
+匀 yun2
+匃 gai4
+匄 gai4
+包 bao1
+匆 cong1
+匈 xiong1
+匉 peng1
+匊 ju2
+匋 tao2
+匌 ge2
+匍 pu2
+匎 an4
+匏 pao2
+匐 fu2
+匑 gong1
+匒 da2
+匓 jiu4
+匔 qiong1 qiong2
+匕 bi3
+化 hua4 hua1
+北 bei3 bei4
+匘 nao3
+匙 chi2 shi5
+匚 fang1
+匛 jiu4
+匜 yi2
+匝 za1
+匞 jiang4
+匟 kang4
+匠 jiang4
+匡 kuang1
+匢 hu1
+匣 xia2
+匤 qu1
+匥 bian4
+匦 gui3
+匧 qie4
+匨 zang1 cang2
+匩 kuang1
+匪 fei3 fei1
+匫 hu1
+匬 tou2
+匭 gui3
+匮 gui4 kui4
+匯 hui4
+匰 dan1
+匱 gui4 kui4
+匲 lian2
+匳 lian2
+匴 suan3
+匵 du2
+匶 jiu4
+匷 qu2
+匸 xi3
+匹 pi3
+区 qu1 ou1
+医 yi4 yi1
+匼 qia4 an3 ke1
+匽 yan3
+匾 bian3
+匿 ni4
+區 qu1 ou1
+十 shi2
+卂 xin4
+千 qian1
+卄 nian4
+卅 sa4
+卆 zu2
+升 sheng1
+午 wu3
+卉 hui4
+半 ban4
+卋 shi4
+卌 xi4
+卍 wan4
+华 hua2 hua4 hua1
+协 xie2
+卐 wan4
+卑 bei1
+卒 zu2 cu4
+卓 zhuo1
+協 xie2
+单 dan1 shan4 chan2
+卖 mai4
+南 nan2 na1
+単 dan1
+卙 ji2
+博 bo2
+卛 shuai4
+卜 bu3
+卝 kuang4
+卞 bian4
+卟 bu3
+占 zhan1 zhan4
+卡 qia3 ka3
+卢 lu2
+卣 you3
+卤 lu3
+卥 xi1
+卦 gua4
+卧 wo4
+卨 xie4
+卩 jie2 bu4
+卪 jie2
+卫 wei4
+卬 ang2 yang3
+卭 qiong2
+卮 zhi1
+卯 mao3
+印 yin4
+危 wei1 wei2
+卲 shao4
+即 ji2
+却 que4
+卵 luan3
+卶 shi4
+卷 juan4 quan2
+卸 xie4
+卹 xu4
+卺 jin3
+卻 que4
+卼 wu4
+卽 ji2
+卾 e4
+卿 qing1
+厀 xi1
+厂 chang3 han4 an1
+厃 zhan1
+厄 e4
+厅 ting1
+历 li4
+厇 zhe2
+厈 han3 an4
+厉 li4
+厊 ya3
+压 ya1 ya4
+厌 yan4 ya1 yan1
+厍 she4
+厎 zhi3
+厏 zha3
+厐 pang2
+厒 he2
+厓 ya2 yai2
+厔 zhi4
+厕 ce4
+厖 pang2 mang2
+厗 ti2
+厘 li2
+厙 she4
+厚 hou4
+厛 ting1
+厜 zui1
+厝 cuo4
+厞 fei4
+原 yuan2 yuan4
+厠 ce4
+厡 yuan2
+厢 xiang1
+厣 yan3
+厤 li4
+厥 jue2
+厦 sha4 xia4
+厧 dian1
+厨 chu2
+厩 jiu4
+厪 qin2 jin3
+厫 ao2
+厬 gui3
+厭 yan4 ya1 yan1
+厮 si1
+厯 li4
+厰 chang3
+厱 lan2 qian1
+厲 li4
+厳 yan2
+厴 yan3
+厵 yuan2
+厶 si1 mou3
+厷 gong1
+厸 lin2 mian3
+厹 qiu2
+厺 qu4
+去 qu4
+厽 lei3
+厾 du1
+县 xian4 xuan2
+叀 zhuan1 hui4
+叁 san1
+参 can1 san1 shen1 den1 cen1 san3
+參 can1 san1 shen1 den1 cen1
+叄 can1 cen1 can4 shen1 san1 san3
+叅 can1 can4 cen1
+叆 ai4
+叇 dai4
+又 you4
+叉 cha1 cha2 cha3 cha4 chai1 cha5
+及 ji2
+友 you3
+双 shuang1
+反 fan3 fan1
+収 shou1
+叏 guai4
+叐 ba2
+发 fa1 fa4 fa3 bo1
+叒 ruo4
+叓 shi4 li4
+叔 shu1
+叕 zhuo2
+取 qu3 qu1
+受 shou4
+变 bian4
+叙 xu4
+叚 jia3 jia4 xia2
+叛 pan4
+叜 sou3
+叝 gao4
+叞 wei4
+叟 sou3
+叠 die2
+叡 rui4
+叢 cong2
+口 kou3
+古 gu3
+句 ju4 gou1
+另 ling4
+叧 gua3
+叨 dao1 tao1
+叩 kou4
+只 zhi3 zhi1
+叫 jiao4
+召 zhao4 shao4
+叭 ba1 ba5
+叮 ding1
+可 ke3 ke4
+台 tai2 yi2 tai1
+叱 chi4
+史 shi3
+右 you4
+叴 qiu2
+叵 po3
+叶 ye4 xie2 she4
+号 hao4 hao2
+司 si1
+叹 tan4
+叺 chi3
+叻 le4
+叼 diao1
+叽 ji1
+叿 hong1
+吀 mie1
+吁 yu4 xu1
+吂 mang2
+吃 chi1 ji1
+各 ge4
+吅 xuan1
+吆 yao1
+吇 zi3
+合 he2 ge3
+吉 ji2
+吊 diao4
+吋 cun4
+同 tong2 tong4
+名 ming2
+后 hou4
+吏 li4
+吐 tu3 tu4
+向 xiang4
+吒 zha4 cha4 zha1
+吓 xia4 he4
+吔 ye3
+吕 lv3
+吖 a1
+吗 ma5 ma2 ma3
+吘 ou3
+吙 xue1
+吚 yi1
+君 jun1
+吜 chou3
+吝 lin4
+吞 tun1
+吟 yin2
+吠 fei4
+吡 bi3
+吢 qin4
+吣 qin4
+吤 jie4
+吥 bu4
+否 fou3 pi3
+吧 ba5 ba1
+吨 dun1
+吩 fen1
+吪 e2
+含 han2
+听 ting1 ting4 yin2
+吭 hang2 keng1
+吮 shun3
+启 qi3
+吰 hong2
+吱 zhi1 zi1
+吲 shen3 yin3
+吳 wu2
+吴 wu2
+吵 chao3
+吶 ne5 ne4 na4
+吷 xue4
+吸 xi1
+吹 chui1 chui4
+吺 dou1
+吻 wen3
+吼 hou3
+吽 ou1 hong1 hou3 ou2
+吾 wu2
+吿 gao4
+呀 ya1 ya5
+呁 jun4
+呂 lv3
+呃 e4
+呄 ge2
+呅 mei2
+呆 dai1 ai2
+呇 qi3
+呈 cheng2
+呉 wu2
+告 gao4
+呋 fu1
+呌 jiao4
+呍 hong1
+呎 chi3
+呏 sheng1
+呐 ne4 na4
+呑 tun1
+呒 fu3
+呓 yi4
+呔 dai1
+呕 ou1 ou3 ou4
+呖 li4
+呗 bei5 bai4
+员 yuan2 yun4
+呙 kuai1 guo1 wai1
+呛 qiang1 qiang4
+呜 wu1
+呝 e4
+呞 shi1 chi1
+呟 quan3
+呠 pen1
+呡 wen3
+呢 ni2 ne5
+呤 ling2 ling4 ling3
+呥 ran3 ran2
+呦 you1
+呧 di3
+周 zhou1
+呩 shi4
+呪 zhou4
+呫 tie1 che4
+呬 xi4
+呭 yi4
+呮 qi4
+呯 ping2
+呰 zi3
+呱 gua1 gu1
+呲 zi1
+味 wei4
+呴 xu1 hou3 hou1
+呵 he1
+呶 nao2
+呷 xia1
+呸 pei1
+呹 yi4
+呺 xiao1 hao2
+呻 shen1
+呼 hu1 xu1
+命 ming4
+呾 da2
+呿 qu1
+咀 ju3 zu3
+咂 za1
+咃 tuo1
+咄 duo1
+咅 pou4
+咆 pao2
+咇 bi4
+咈 fu2
+咉 yang1
+咊 he2 huo4 huo2 he4
+咋 zha4 ze2
+和 he2 huo4 huo2 he4
+咍 hai1
+咎 jiu4 gao1
+咏 yong3
+咐 fu4
+咑 que4 que1 jue2
+咒 zhou4
+咓 wa3
+咔 ka3
+咕 gu1
+咖 ka1 ga1
+咗 zuo3
+咘 bu4
+咙 long2
+咚 dong1
+咛 ning2
+咝 si1
+咞 xian4 xian2
+咟 huo4
+咠 qi4
+咡 er4
+咢 e4
+咣 guang1
+咤 zha4 cha4 zha1
+咥 xi4 xi1 die2 zhi4
+咦 yi2
+咧 lie3 lie5
+咨 zi1
+咩 mie1
+咪 mi1
+咫 zhi3
+咬 yao3 jiao1
+咭 ji1
+咮 zhou4
+咯 ge1 ka3 lo5
+咰 shuai4
+咱 zan2 za2
+咲 xiao4
+咳 ke2 hai1 hai2 kai4
+咴 hui1
+咵 kua1
+咶 huai4 hua2 shi4
+咷 tao2
+咸 xian2
+咹 e4
+咺 xuan3 xuan1
+咻 xiu1 xu3
+咼 wai1
+咽 yan1 yan4 ye4
+咾 lao3
+咿 yi1
+哀 ai1
+品 pin3
+哂 shen3
+哃 tong2
+哄 hong1 hong3 hong4
+哅 xiong1
+哆 duo1 chi3
+哇 wa1 wa5
+哈 ha1 ha3 ha4
+哉 zai1
+哊 yu4
+哋 di4 dei1
+哌 pai4
+响 xiang3
+哎 ai1
+哏 hen3 gen2
+哐 kuang1
+哑 ya3 ya1 e4
+哒 da1
+哓 xiao1
+哔 bi4
+哕 yue3 hui4
+哗 hua1 hua2
+哙 kuai4
+哚 duo3
+哜 ji4
+哝 nong2
+哞 mou1
+哟 yo5
+哠 hao4
+員 yuan2 yun4
+哢 long4
+哣 pou3
+哤 mang2
+哥 ge1
+哦 o4 o2 e2
+哧 chi1
+哨 shao4
+哩 li1 li5 li3
+哪 na3 nei3 na5 ne2
+哫 zu2
+哬 he2
+哭 ku1
+哮 xiao1
+哯 xian4
+哰 lao2
+哱 bo1
+哲 zhe2
+哳 zha1
+哴 liang4 lang2
+哵 ba1
+哶 mie1
+哷 le4
+哸 sui1
+哹 fou2
+哺 bu3
+哻 han4
+哼 heng1
+哽 geng3
+哾 shuo1
+哿 ge3 ke3
+唀 you3
+唁 yan4
+唂 gu3
+唃 gu3
+唄 bei5 bai4
+唅 han1 han2 han4
+唆 suo1
+唇 chun2
+唈 yi4
+唉 ai1 ai4
+唊 jia2 qian3
+唋 tu3
+唌 xian2 yan2 dan4
+唍 huan3
+唎 li4 li1
+唏 xi1
+唐 tang2
+唑 zuo4
+唒 qiu2
+唓 che1
+唔 wu2
+唕 zao4
+唖 ya3
+唗 dou1
+唘 qi3
+唙 di2
+唚 qin4
+唛 ma4
+唝 hong3 gong4
+唞 dou3
+唠 lao2
+唡 liang3
+唢 suo3
+唣 zao4
+唤 huan4
+唦 sha1
+唧 ji1
+唨 zuo3 zu3
+唩 wo1
+唪 feng3 beng3
+唫 yin2
+唬 hu3
+唭 qi1
+售 shou4
+唯 wei2 wei3
+唰 shua1
+唱 chang4
+唲 er2
+唳 li4
+唴 qiang4
+唵 an3
+唶 jie4 ji2 ze4
+唷 yo1
+唸 nian4
+唹 yu1 yo1
+唺 tian3
+唻 lai3
+唼 sha4 za1 qie4
+唽 xi1
+唾 tuo4
+唿 hu1
+啀 ai2
+啁 zhou1 zhao1
+啂 nou4
+啃 ken3
+啄 zhuo2 zhou4
+啅 zhuo2
+商 shang1
+啇 di2
+啈 heng4
+啉 lan2 lin2
+啊 a5
+啋 xiao1
+啌 xiang1 qiang1
+啍 tun1
+啎 wu3
+問 wen4
+啐 cui4
+啑 sha4 die2
+啒 hu1
+啓 qi3
+啔 qi3
+啕 tao2
+啖 dan4
+啗 dan4
+啘 ye4 wa1
+啙 zi3
+啚 bi3 tu2
+啛 cui4
+啜 chuo4
+啝 he2
+啞 ya3 ya1 e4
+啟 qi3
+啠 zhe2
+啡 fei1 pei1
+啢 liang3
+啣 xian2
+啤 pi2
+啥 sha4
+啦 la5 la1
+啧 ze2
+啨 qing1
+啩 gua4
+啪 pa1
+啫 zhe3
+啬 se4
+啭 zhuan4
+啮 nie4
+啯 guo5
+啰 luo1 luo2 luo5
+啱 yan1
+啲 di4
+啳 quan2 jue2
+啴 tan1 chan3
+啵 bo5
+啶 ding4
+啷 lang1 lang2
+啸 xiao4
+啺 tang2
+啻 chi4
+啼 ti2
+啽 an2
+啾 jiu1
+啿 dan4
+喀 ka1 ke4 ke5
+喁 yong2 yu2
+喂 wei4
+喃 nan2
+善 shan4
+喅 yu4
+喆 zhe2
+喇 la3
+喈 jie1
+喉 hou2
+喊 han3
+喋 die2 zha2
+喌 zhou1
+喍 chai2
+喎 wai1
+喏 re3 nuo4
+喐 yu4
+喑 yin1 yin4
+喒 zan2
+喓 yao1
+喔 o1 wo1
+喕 mian3
+喖 hu2
+喗 yun3
+喘 chuan3
+喙 hui4
+喚 huan4
+喛 huan4 yuan2 xuan3 he2
+喜 xi3
+喝 he1 he4
+喞 ji1
+喟 kui4
+喠 zhong3
+喡 wei3
+喢 sha4
+喣 xu3
+喤 huang2
+喥 du4
+喦 nie4
+喧 xuan1 xuan3
+喨 liang4
+喩 yu4
+喪 sang1 sang4
+喫 chi1 ji1
+喬 qiao2
+喭 yan4
+單 dan1 shan4 chan2
+喯 pen1
+喰 can1
+喱 li2
+喲 yo5
+喳 zha1 cha1
+喴 wei1
+喵 miao1
+営 ying2
+喷 pen1 pen4
+喹 kui2
+喺 xi4
+喻 yu4 yu2
+喼 jie2
+喽 lou5 lou2
+喾 ku4
+喿 sao4
+嗀 huo4
+嗁 ti2
+嗂 yao2
+嗃 he4 xiao1 xiao4
+嗄 a2 sha4
+嗅 xiu4
+嗆 qiang1 qiang4
+嗇 se4
+嗈 yong1
+嗉 su4
+嗊 hong3 gong4
+嗋 xie2
+嗌 yi4 ai4
+嗍 suo1
+嗎 ma5 ma2 ma3
+嗏 cha1
+嗐 hai4
+嗑 ke4 he2
+嗒 ta4
+嗓 sang3
+嗔 tian2 chen1
+嗕 ru4
+嗖 sou1
+嗗 wa1
+嗘 ji1
+嗙 pang3
+嗚 wu1
+嗛 xian2 qian4 qian3 qie4
+嗜 shi4
+嗝 ge2
+嗞 zi1
+嗟 jie1 jue1
+嗠 luo4
+嗡 weng1
+嗢 wa4
+嗣 si4
+嗤 chi1
+嗥 hao2
+嗦 suo1
+嗨 hai1 hai3
+嗩 suo3
+嗪 qin2
+嗫 nie4
+嗬 he1
+嗮 sai4
+嗰 ge4
+嗱 na2
+嗲 dia3
+嗳 ai4 ai3 ai1
+嗵 tong1
+嗶 bi4
+嗷 ao2
+嗸 ao2
+嗹 lian2
+嗺 cui1
+嗻 zhe1
+嗼 mo4
+嗽 sou4
+嗾 sou3
+嗿 tan3
+嘀 di2
+嘁 qi1
+嘂 jiao4
+嘃 chong1
+嘄 jiao1
+嘅 kai3
+嘆 tan4
+嘇 san1
+嘈 cao2
+嘉 jia1
+嘊 ai2
+嘋 xiao1
+嘌 piao1 piao4
+嘍 lou5 lou2
+嘎 ga1 ga3
+嘏 gu3 jia3
+嘐 xiao1 jiao1
+嘑 hu1 hu4 la4
+嘒 hui4
+嘓 guo1
+嘔 ou1 ou3 ou4 xu1 ou5
+嘕 xian1
+嘖 ze2
+嘗 chang2
+嘘 xu1
+嘙 po2
+嘚 de2 de1 dai1
+嘛 ma5
+嘜 ma4
+嘝 hu2
+嘞 lei5
+嘟 du1
+嘠 ga1 ga3
+嘡 tang1
+嘢 ye3
+嘣 beng1
+嘤 ying1
+嘦 jiao4
+嘧 mi4
+嘨 xiao4 chi4
+嘩 hua1 hua2
+嘪 mai3
+嘫 ran2
+嘬 zuo1 chuai4
+嘭 peng1
+嘮 lao2
+嘯 xiao4
+嘰 ji1
+嘱 zhu3
+嘲 chao2 zhao1
+嘳 kui4
+嘴 zui3
+嘵 xiao1
+嘶 si1 xi1
+嘷 hao2
+嘸 fu3
+嘹 liao2 liao4
+嘺 qiao2
+嘻 xi1
+嘼 xiu4
+嘽 tan1 chan3
+嘾 tan2
+嘿 hei1 mo4
+噀 xun4
+噁 e3 wu4
+噂 zun3
+噃 fan1
+噄 chi1
+噅 hui1
+噆 zan3
+噇 chuang2
+噈 cu4
+噉 dan4
+噊 yu4
+噋 tun1 kuo4
+噌 cheng1 ceng1
+噍 jiao4 jiao1
+噎 ye1
+噏 xi1
+噐 qi4
+噑 hao2
+噒 lian2
+噓 xu1
+噔 deng1
+噕 hui1
+噖 yin2
+噗 pu1
+噘 jue1
+噙 qin2
+噚 xun2
+噛 nie4
+噜 lu1
+噝 si1
+噞 yan3
+噟 ying4
+噠 da1
+噡 dan1 zhan1
+噢 o1 yu3
+噣 zhou4 zhuo2
+噤 jin4
+噥 nong2
+噦 yue3 hui4
+噧 hui4
+器 qi4
+噩 e4
+噪 zao4
+噫 yi1
+噬 shi4
+噭 jiao4
+噮 yuan1
+噯 ai3 ai4 ai1
+噰 yong1
+噱 jue2 xue2
+噲 kuai4
+噳 yu3
+噴 pen1 pen4
+噵 dao4
+噶 ge2 ga2
+噷 xin1 hen1
+噸 dun1
+噹 dang1
+噻 sai5
+噼 pi1
+噽 pi3
+噾 yin1
+噿 zui3
+嚀 ning2
+嚁 di2
+嚂 lan4 han3 lan2
+嚃 ta4
+嚄 huo4 huo1
+嚅 ru2
+嚆 hao1
+嚇 xia4 he4
+嚈 ya4
+嚉 duo1
+嚊 xi4
+嚋 chou2
+嚌 ji4
+嚍 jin4
+嚎 hao2
+嚏 ti4
+嚐 chang2
+嚓 ca1
+嚔 ti4
+嚕 lu1
+嚖 hui4
+嚗 bo2
+嚘 you1
+嚙 nie4
+嚚 yin2
+嚛 hu4
+嚜 mo4 me5 ma5
+嚝 huang1
+嚞 zhe2
+嚟 li2
+嚠 liu2 liu1
+嚢 nang2
+嚣 xiao1 ao2
+嚤 mo2
+嚥 yan4
+嚦 li4
+嚧 lu2
+嚨 long2
+嚩 fu2 po2
+嚪 dan4
+嚫 chen4
+嚬 pin2
+嚭 pi3
+嚮 xiang4
+嚯 huo4
+嚰 mo2
+嚱 xi4
+嚲 duo3
+嚳 ku4
+嚴 yan2
+嚵 chan2
+嚶 ying1
+嚷 rang3 rang1
+嚸 dian3
+嚹 la1
+嚺 ta4
+嚻 xiao1
+嚼 jiao2 jue2 jiao4
+嚽 chuo4
+嚾 huan1
+嚿 huo4
+囀 zhuan4
+囁 nie4
+囂 xiao1
+囃 ca4
+囄 li2 lei1
+囅 chan3
+囆 chai4
+囇 li4
+囈 yi4
+囉 luo1 lou2
+囊 nang2
+囋 zan4
+囌 su1
+囍 xi3
+囏 jian1
+囐 za2 zan2
+囑 zhu3
+囒 lan2
+囓 nie4
+囔 nang1
+囗 wei2
+囘 hui2
+囙 yin1
+囚 qiu2
+四 si4
+囜 nin2
+囝 jian3 nan1
+回 hui2
+囟 xin4
+因 yin1
+囡 nan1
+团 tuan2
+団 tuan2
+囤 dun4 tun2
+囥 kang4
+囦 yuan1
+囧 jiong3
+囨 pian1
+囩 yun4
+囪 cong1 chuang1
+囫 hu2
+囬 hui2
+园 yuan2
+囮 e2 you2
+囯 guo2
+困 kun4
+囱 cong1 chuang1
+囲 wei2
+図 tu2
+围 wei2
+囵 lun2
+囶 guo2
+囷 qun1
+囸 ri4
+囹 ling2
+固 gu4
+囻 guo2
+囼 tai1
+国 guo2
+图 tu2
+囿 you4
+圀 guo2
+圁 yin2
+圂 hun4
+圃 pu3
+圄 yu3
+圅 han2
+圆 yuan2
+圇 lun2
+圈 quan1 juan4
+圉 yu3
+圊 qing1
+國 guo2
+圌 chuan2 chui2
+圍 wei2
+圎 yuan2
+圏 quan1
+圐 ku1
+圑 fu4
+園 yuan2
+圓 yuan2
+圔 e4
+圖 tu2
+圗 tu2
+團 tuan2
+圙 lve4
+圚 hui4
+圛 yi4
+圜 yuan2 huan2
+圝 luan2
+圞 luan2
+土 tu3
+圠 ya4
+圡 tu3
+圢 ting1 ting3
+圣 sheng4 ku1
+圤 pu3 pu2
+圥 lu4
+圧 ya1
+在 zai4
+圩 wei2 yu2 xu1
+圪 ge1
+圫 yu4 ao4
+圬 wu1
+圭 gui1
+圮 pi3
+圯 yi2
+地 di4 de5
+圱 qian1
+圲 qian1
+圳 zhen4
+圴 zhuo2
+圵 dang4
+圶 qia4
+圹 kuang4
+场 chang2 chang3
+圻 qi2 yin2
+圼 nie4
+圽 mo4
+圾 ji2 ji1
+圿 jia2
+址 zhi3
+坁 zhi3
+坂 ban3
+坃 xun1 xun4
+坄 tou2
+坅 qin3
+坆 fen2
+均 jun1 yun4
+坈 keng1
+坉 tun2
+坊 fang1 fang2
+坋 fen4
+坌 ben4
+坍 tan1
+坎 kan3
+坏 huai4 pi1 pei2
+坐 zuo4
+坑 keng1
+坒 bi4
+坓 xing2
+坔 di4
+坕 jing1
+坖 ji4
+块 kuai4
+坘 di3
+坙 jing1
+坚 jian1
+坛 tan2
+坜 li4
+坝 ba4
+坞 wu4
+坟 fen2
+坠 zhui4
+坡 po1
+坢 pan3 pan4
+坣 tang1
+坤 kun1
+坥 qu1
+坦 tan3
+坧 zhi1
+坨 tuo2
+坩 gan1
+坪 ping2
+坫 dian4
+坬 gua4
+坭 ni2 ni4
+坮 tai2
+坯 pi1
+坰 jiong1
+坱 yang3
+坲 fo2
+坳 ao4 ao1
+坴 liu4
+坵 qiu1
+坶 mu4
+坷 ke3 ke1
+坸 gou4
+坹 xue4
+坺 ba2 bo1
+坻 chi2 di3
+坼 che4
+坽 ling2
+坾 zhu4
+坿 fu4
+垀 hu1
+垁 zhi4
+垂 chui2
+垃 la1 la5
+垄 long3
+垅 long3
+垆 lu2
+垇 ao4 ao1
+垉 pao2
+型 xing2
+垌 dong4 tong2
+垍 ji4
+垎 ke4
+垏 lu4
+垐 ci2
+垑 chi3
+垒 lei3 lei4 lei2 lv4
+垓 gai1
+垔 yin1
+垕 hou4
+垖 dui1
+垗 zhao4
+垘 fu2
+垙 guang1
+垚 yao2
+垛 duo3
+垜 duo3
+垝 gui3
+垞 cha2
+垟 yang2
+垠 yin2
+垡 fa2
+垢 gou4
+垣 yuan2
+垤 die2
+垥 xie2
+垦 ken3
+垧 jiong1 shang3
+垨 shou3
+垩 e4
+垫 dian4
+垬 hong2
+垭 wu4 ya4
+垮 kua3
+垱 dang4
+垲 kai3
+垴 nao3
+垵 an3
+垶 xing1
+垷 xian4
+垸 huan4
+垹 bang1
+垺 pei1 fu2 pou2
+垻 ba4
+垼 yi4
+垽 yin4
+垾 han4
+垿 xu4
+埀 chui2 zhui4
+埁 cen2
+埂 geng3
+埃 ai1
+埄 peng2
+埅 fang2 fang1 di4
+埆 que4
+埇 yong3
+埈 xun4
+埉 jia2
+埊 di4
+埋 mai2 man2
+埌 lang4
+埍 xuan4
+城 cheng2
+埏 yan2 shan1
+埐 jin1
+埑 zhe2
+埒 lei4
+埓 lie4
+埔 pu3 bu4
+埕 cheng2
+埗 bu4
+埘 shi2
+埙 xun1 xuan1
+埚 guo1
+埛 jiong1
+埜 ye3
+埝 nian4
+埞 di3
+域 yu4
+埠 bu4
+埡 ya4
+埢 juan3
+埣 sui4
+埤 pi2 bei1 bi4
+埥 cheng1
+埦 wan3
+埧 ju4
+埨 lun3 lun4
+埩 zheng1
+埪 kong1
+埫 chong3
+埬 dong1
+埭 dai4
+埮 tan4
+埯 an3
+埰 cai4
+埱 shu2
+埲 beng3 bang4
+埳 kan3
+埴 zhi2
+埵 duo3
+埶 yi4 shi4
+執 zhi2
+埸 yi4
+培 pei2 pou3
+基 ji1
+埻 zhun3
+埼 qi2
+埽 sao4 sao3
+埾 ju4
+埿 ni2 ban4
+堀 ku1
+堁 ke4
+堂 tang2
+堃 kun1
+堄 ni4
+堅 jian1
+堆 dui1
+堇 jin3
+堈 gang1
+堉 yu4
+堊 e4
+堋 peng2 beng4
+堌 gu4
+堍 tu4
+堎 leng4
+堐 ya2
+堑 qian4
+堓 an4
+堕 duo4 hui1
+堖 nao3
+堗 tu1
+堘 cheng2
+堙 yin1
+堚 hun2
+堛 bi4
+堜 lian4
+堝 guo1
+堞 die2
+堟 zhuan4
+堠 hou4
+堡 bao3 bu3 pu4
+堢 bao3
+堣 yu2
+堤 di1 ti2
+堥 mao2
+堦 jie1
+堧 ruan2
+堨 e4 ai4 ye4
+堩 geng4
+堪 kan1
+堫 zong1
+堬 yu2
+堭 huang2
+堮 e4
+堯 yao2
+堰 yan4
+報 bao4
+堲 ji2
+堳 mei2
+場 chang2 chang3
+堵 du3
+堶 tuo2
+堷 yin4 pou3
+堸 feng2
+堹 zhong4
+堺 jie4
+堻 zhen1
+堼 feng1
+堽 gang1
+堾 chuan3 chun3 chun1
+堿 jian3
+塂 xiang4 jiang3
+塃 huang1
+塄 leng2
+塅 duan4
+塇 xuan1
+塈 ji4 xi4
+塉 ji2
+塊 kuai4
+塋 ying2
+塌 ta1
+塍 cheng2
+塎 yong3
+塏 kai3
+塐 su4
+塑 su4
+塒 shi2
+塓 mi4
+塔 ta3
+塕 weng3
+塖 cheng2
+塗 tu2
+塘 tang2
+塙 que4
+塚 zhong3
+塛 li4
+塜 peng2
+塝 bang4
+塞 sai1 se4 sai4
+塟 zang4
+塠 dui1
+塡 tian2
+塢 wu4
+塣 cheng3
+塤 xun1 xuan1
+塥 ge2
+塦 zhen4
+塧 ai4
+塨 gong1
+塩 yan2
+塪 kan3 xian4
+填 tian2
+塬 yuan2
+塭 wen1
+塮 xie4
+塯 liu4
+塱 lang3
+塲 chang2 chang3
+塳 peng2
+塴 beng4
+塵 chen2
+塶 cu4
+塷 lu3
+塸 ou3 ou1
+塹 qian4
+塺 mei2 mo4
+塻 mo4
+塼 zhuan1
+塽 shuang3
+塾 shu2
+塿 lou3
+墀 chi2
+墁 man4
+墂 biao1
+境 jing4
+墄 qi1
+墅 shu4
+墆 di4 die2
+墇 zhang1
+墈 kan4
+墉 yong1 yong2
+墊 dian4
+墋 chen3
+墌 zhi1
+墍 xi4 ji4
+墎 guo1 guo4
+墏 qiang3
+墐 jin4
+墑 di1
+墒 shang1
+墓 mu4
+墔 cui1
+墕 yan4
+墖 ta3
+増 zeng1
+墘 qi2
+墙 qiang2
+墚 liang2
+墜 zhui4
+墝 qiao1
+增 zeng1
+墟 xu1
+墠 shan4
+墡 shan4
+墢 ba2 fei4 bo1
+墣 pu1 pu2
+墤 kuai4 tui2
+墥 dong3
+墦 fan2
+墧 que4 qiao2
+墨 mo4
+墩 dun1
+墪 dun1
+墫 zun1 cun2
+墬 di4 de5
+墭 sheng4
+墮 duo4 hui1
+墯 duo4 hui1
+墰 tan2
+墱 deng4
+墲 wu3
+墳 fen2
+墴 huang2
+墵 tan2
+墶 da1 da5
+墷 ye4
+墺 ao4 yu4
+墻 qiang2
+墼 ji1
+墽 qiao1
+墾 ken3
+墿 yi4
+壀 pi2 bi4 pi4 bei1
+壁 bi4
+壂 dian4
+壃 jiang1
+壄 ye3
+壅 yong1 yong3
+壆 bo2
+壇 tan2
+壈 lan3
+壉 ju4
+壊 huai4
+壋 dang4
+壌 rang3
+壍 qian4
+壎 xun1 xuan1
+壏 lan4 han3
+壐 xi3
+壑 he4 huo4
+壒 ai4
+壓 ya1 ya4
+壔 dao3
+壕 hao2
+壖 ruan2
+壘 lei3 lei4 lei2 lv4
+壙 kuang4
+壚 lu2
+壛 yan2
+壜 tan2
+壝 wei2 wei3
+壞 huai4
+壟 long3
+壠 long3
+壡 rui4
+壢 li4
+壣 lin2
+壤 rang3
+壦 xun1 xun4
+壧 yan2
+壨 lei2
+壩 ba4
+士 shi4
+壬 ren2
+壮 zhuang4
+壯 zhuang4
+声 sheng1
+壱 yi1
+売 mai4
+壳 ke2 qiao4
+壴 zhu3
+壵 zhuang4
+壶 hu2
+壷 hu2
+壸 kun3
+壹 yi1 yi4
+壺 hu2
+壻 xu4
+壼 kun3
+壽 shou4
+壾 mang3
+壿 zun1 cun1 zun3
+夀 shou4
+夁 yi1 yin1
+夂 zhi3
+夃 gu1
+处 chu4 chu3
+夅 jiang4
+夆 feng2 pang2
+备 bei4
+変 bian4
+夊 sui1
+夋 qun1
+夌 ling2
+复 fu4
+夎 zuo4
+夏 xia4 jia3
+夐 xiong4
+夒 nao2
+夓 xia4
+夔 kui2
+夕 xi1 xi4
+外 wai4
+夗 yuan4 wan3
+夘 mao3
+夙 su4
+多 duo1
+夛 duo1
+夜 ye4
+夝 qing2
+够 gou4
+夠 gou4
+夡 qi4
+夢 meng4 meng2
+夣 meng4
+夤 yin2
+夥 huo3
+夦 chen4
+大 da4 dai4 tai4
+夨 ze4
+天 tian1
+太 tai4
+夫 fu1 fu2
+夬 guai4
+夭 yao1 wo4 wai1 yao3
+央 yang1
+夯 hang1 ben4
+夰 gao3
+失 shi1
+夲 ben3 tao1
+夳 tai4
+头 tou2 tou5
+夵 yan3
+夶 bi3
+夷 yi2
+夸 kua1
+夹 jia1 jia2
+夺 duo2
+夼 kuang3
+夽 yun4
+夾 jia1 jia2
+夿 pa1 ba1
+奀 en1 mang2
+奁 lian2
+奂 huan4
+奃 di4 di1
+奄 yan3 yan1
+奅 pao4
+奆 quan3
+奇 qi2 ji1
+奈 nai4
+奉 feng4
+奊 xie2
+奋 fen4
+奌 dian3
+奎 kui2
+奏 zou4
+奐 huan4
+契 qi4 qie4 xie4
+奒 kai1 zha1 zha4
+奓 she1 chi3 zha4 zha1
+奔 ben1 ben4
+奕 yi4
+奖 jiang3
+套 tao4
+奘 zang4 zhuang3
+奙 ben3
+奚 xi1 xi2
+奛 xiang3
+奜 fei3
+奝 diao1
+奞 xun4
+奟 keng1
+奠 dian4
+奡 ao4
+奢 she1
+奣 weng3
+奤 pan3 ha3 tai3
+奥 ao4
+奦 wu4
+奧 ao4 yu4
+奨 jiang3
+奩 lian2
+奪 duo2
+奫 yun1
+奬 jiang3
+奭 shi4
+奮 fen4
+奯 huo4
+奰 bi4
+奱 lian2
+奲 duo3
+女 nv3 ru3
+奴 nu2
+奵 ding1
+奶 nai3
+奷 qian1
+奸 jian1
+她 ta1
+奺 jiu3
+奻 nan2
+奼 cha4
+好 hao3 hao4
+奾 xian1
+奿 fan4
+妀 ji3
+妁 shuo4
+如 ru2
+妃 fei1 pei4
+妄 wang4
+妅 hong2
+妆 zhuang1
+妇 fu4
+妈 ma1
+妉 dan1
+妊 ren4
+妋 fu1
+妌 jing4
+妍 yan2
+妎 xie4
+妏 wen4
+妐 zhong1
+妑 pa1
+妒 du4
+妓 ji4
+妔 keng1
+妕 zhong4
+妖 yao1
+妗 jin4
+妘 yun2
+妙 miao4
+妚 pei1
+妜 yue4
+妝 zhuang1
+妞 niu1
+妟 yan4
+妠 na4
+妡 xin1
+妢 fen2
+妣 bi3
+妤 yu2
+妥 tuo3
+妦 feng1
+妧 yuan2
+妨 fang2 fang1
+妩 wu3
+妪 yu4 yu3
+妫 gui1
+妬 du4
+妭 ba2
+妮 ni1 ni2
+妯 zhou2 zhu2
+妰 zhuo2
+妱 zhao1
+妲 da2
+妳 ni3 nai3
+妴 yuan3
+妵 tou3
+妶 xuan2
+妷 zhi2
+妸 e1
+妹 mei4
+妺 mo4
+妻 qi1 qi4
+妼 bi4
+妽 shen1
+妾 qie4
+妿 e1
+姀 he2
+姁 xu3 xu1
+姂 fa2
+姃 zheng1
+姄 min2
+姅 ban4
+姆 mu3
+姇 fu1
+姈 ling2
+姉 zi3
+姊 zi3
+始 shi3
+姌 ran3
+姍 shan1
+姎 yang1
+姏 man2
+姐 jie3
+姑 gu1
+姒 si4
+姓 xing4
+委 wei3 wei1
+姕 zi1
+姖 ju4
+姗 shan1
+姘 pin1
+姙 ren4
+姚 yao2
+姛 tong3
+姜 jiang1
+姝 shu1
+姞 ji2
+姟 gai1
+姠 shang4
+姡 kuo4
+姢 juan1
+姣 jiao1 jiao3 xiao2
+姤 gou4
+姥 mu3 lao3
+姦 jian1
+姧 jian1
+姨 yi2
+姩 nian4
+姪 zhi2
+姫 ji1
+姬 ji1
+姭 xian4
+姮 heng2
+姯 guang1
+姰 jun1
+姱 kua1
+姲 yan4
+姳 ming3
+姴 lie4
+姵 pei4
+姶 yan3
+姷 you4
+姸 yan2
+姹 cha4
+姺 shen1 xian3 xian1
+姻 yin1
+姼 chi3
+姽 gui3
+姾 quan1
+姿 zi1
+娀 song1
+威 wei1
+娂 hong2
+娃 wa2
+娄 lou2
+娅 ya4
+娆 rao3 rao2
+娇 jiao1
+娈 luan2 lian4
+娉 ping1
+娊 xian4
+娋 shao4
+娌 li3
+娍 cheng2
+娎 xiao4 xie1
+娏 mang2
+娑 suo1
+娒 wu3
+娓 wei3
+娔 ke4
+娕 lai4
+娖 chuo4
+娗 ding4
+娘 niang2
+娙 xing2
+娚 nan2
+娛 yu2
+娜 nuo2 na4
+娝 pei1
+娞 nei3
+娟 juan1
+娠 shen1
+娡 zhi4
+娢 han2
+娣 di4
+娤 zhuang1
+娥 e2
+娦 pin2
+娧 tui4
+娨 han4
+娩 mian3 wan3
+娪 wu2
+娫 yan2
+娬 wu3
+娭 xi1 ai1
+娮 yan2
+娯 yu2
+娰 si4
+娱 yu2
+娲 wa1
+娴 xian2
+娵 ju1
+娶 qu3
+娷 shui4
+娸 qi1
+娹 xian2
+娺 zhui1
+娻 dong1
+娼 chang1
+娽 lu4
+娾 ai3
+娿 e1
+婀 e1
+婁 lou2
+婂 mian2
+婃 cong2
+婄 pou3
+婅 ju2
+婆 po2
+婇 cai3
+婈 ding2
+婉 wan3
+婊 biao3
+婋 xiao1
+婌 shu3
+婍 qi3
+婎 hui1
+婏 fu4
+婐 e1 wo3
+婑 wo3
+婒 tan2
+婓 fei1
+婕 jie2
+婖 tian1
+婗 ni2
+婘 quan2 juan4
+婙 jing4
+婚 hun1
+婛 jing1
+婜 qian1
+婝 dian4
+婞 xing4
+婟 hu4
+婠 wan1 wa4
+婡 lai2
+婢 bi4
+婣 yin1
+婤 zhou1 chou1
+婥 chuo4
+婦 fu4
+婧 jing4
+婨 lun2
+婩 yan4
+婪 lan2
+婫 kun1
+婬 yin2
+婭 ya4
+婯 li4
+婰 dian3
+婱 xian2
+婳 hua4
+婴 ying1
+婵 chan2
+婶 shen3
+婷 ting2
+婸 dang4
+婹 yao3
+婺 wu4
+婻 nan4
+婼 ruo4 chuo4
+婽 jia3
+婾 tou1 yu2
+婿 xu4
+媀 yu2
+媁 wei1
+媂 ti2
+媃 rou2
+媄 mei3
+媅 dan1
+媆 ruan3
+媇 qin1
+媉 wu1
+媊 qian2
+媋 chun1
+媌 mao2 miao2
+媍 fu4
+媎 jie3
+媏 duan1
+媐 xi1
+媑 zhong4
+媒 mei2
+媓 huang2
+媔 mian2
+媕 an1
+媖 ying1
+媗 xuan1
+媙 wei1
+媚 mei4
+媛 yuan4 yuan2
+媜 zhen1
+媝 qiu1
+媞 ti2 di4
+媟 xie4
+媠 tuo3 duo4
+媡 lian4
+媢 mao4
+媣 ran3
+媤 si1
+媥 pian1
+媦 wei4
+媧 wa1
+媨 jiu4
+媩 hu2
+媪 ao3
+媭 xu1
+媮 tou1 yu2
+媯 gui1
+媰 zou1
+媱 yao2
+媲 pi4
+媳 xi2
+媴 yuan2
+媵 ying4
+媶 rong2
+媷 ru4
+媸 chi1
+媹 liu2
+媺 mei3
+媻 pan2
+媼 ao3
+媽 ma1
+媾 gou4
+媿 kui4 gui3
+嫀 qin2
+嫁 jia4
+嫂 sao3
+嫃 zhen1
+嫄 yuan2
+嫅 cha1
+嫆 yong2
+嫇 ming2
+嫈 ying1
+嫉 ji2
+嫊 su4
+嫋 niao3
+嫌 xian2
+嫍 tao1
+嫎 pang2
+嫏 lang2
+嫐 nao3
+嫑 bao2
+嫒 ai4
+嫓 pi4
+嫔 pin2
+嫕 yi4
+嫖 piao4 piao2 biao1 piao1
+嫗 yu4 yu3
+嫘 lei2
+嫙 xuan2
+嫚 man4
+嫛 yi1
+嫜 zhang1
+嫝 kang1
+嫞 yong2
+嫟 ni4
+嫠 li2
+嫡 di2
+嫢 gui1
+嫣 yan1
+嫤 jin4
+嫥 zhuan1
+嫦 chang2
+嫧 ce4
+嫨 han1
+嫩 nen4 nun4
+嫪 lao4
+嫫 mo2
+嫬 zhe1
+嫭 hu4
+嫮 hu4
+嫯 ao4
+嫰 nen4 nun4
+嫱 qiang2
+嫳 pie4
+嫴 gu1
+嫵 wu3
+嫶 jiao2
+嫷 tuo3
+嫸 zhan3
+嫹 mao2
+嫺 xian2
+嫻 xian2
+嫼 mo4
+嫽 liao2
+嫾 lian2
+嫿 hua4
+嬀 gui1
+嬁 deng1
+嬂 zhi1
+嬃 xu1
+嬅 hua2
+嬆 xi1
+嬇 hui4
+嬈 rao3 rao2 yao3
+嬉 xi1
+嬊 yan4
+嬋 chan2
+嬌 jiao1
+嬍 mei3
+嬎 fan4
+嬏 fan1
+嬐 xian1
+嬑 yi4
+嬒 wei4
+嬓 jiao4
+嬔 fu4
+嬕 shi4
+嬖 bi4
+嬗 shan4
+嬘 sui4
+嬙 qiang2
+嬚 lian3
+嬛 huan2 qiong2 yuan1
+嬝 niao3
+嬞 dong3
+嬟 yi4
+嬠 can2
+嬡 ai4
+嬢 niang2
+嬣 neng2
+嬤 ma1
+嬥 tiao3 tiao2
+嬦 chou2
+嬧 jin4
+嬨 ci2
+嬩 yu2
+嬪 pin2
+嬬 xu1
+嬭 nai3
+嬮 yan1 yan4
+嬯 tai2
+嬰 ying1
+嬱 can2
+嬲 niao3
+嬴 ying2
+嬵 mian2
+嬷 ma1
+嬸 shen3
+嬹 xing4
+嬺 ni4
+嬻 du2
+嬼 liu3
+嬽 yuan1
+嬾 lan3
+嬿 yan4
+孀 shuang1
+孁 ling2
+孂 jiao3
+孃 niang2 nang2 rang2 rang3
+孄 lan3
+孅 xian1 qian1
+孆 ying1
+孇 shuang1
+孈 shuai1
+孉 quan2
+孊 mi3
+孋 li2
+孌 luan2 lian4
+孍 yan2
+孎 zhu3
+孏 lan3
+子 zi3 zi5
+孑 jie2
+孒 jue2
+孓 jue2
+孔 kong3
+孕 yun4
+孖 zi1 ma1
+字 zi4
+存 cun2
+孙 sun1 xun4
+孚 fu2 fu1
+孛 bei4 bo2
+孜 zi1
+孝 xiao4
+孞 xin4
+孟 meng4
+孠 si4
+孡 tai1
+孢 bao1
+季 ji4
+孤 gu1
+孥 nu2
+学 xue2
+孨 zhuan3
+孩 hai2
+孪 luan2
+孫 sun1 xun4
+孬 nao1 huai4
+孭 mie1
+孮 cong2
+孯 qian1
+孰 shu2
+孱 chan2 can4
+孲 ya1
+孳 zi1 zi4
+孴 ni3
+孵 fu1
+孶 zi1 zi4
+孷 li2
+學 xue2
+孹 bo4
+孺 ru2 ru4
+孻 lai2
+孼 nie4
+孽 nie4
+孾 ying1
+孿 luan2
+宀 mian2
+宁 ning2 zhu4 ning4
+宂 rong3
+它 ta1 tuo1
+宄 gui3
+宅 zhai2
+宆 qiong2
+宇 yu3
+守 shou3 shou4
+安 an1
+宊 tu2
+宋 song4
+完 wan2
+宍 rou4
+宎 yao3 yao1 yao4
+宏 hong2
+宐 yi2
+宑 jing3
+宒 zhun1
+宓 mi4 fu2
+宔 zhu3
+宕 dang4
+宖 hong2
+宗 zong1
+官 guan1
+宙 zhou4
+定 ding4
+宛 wan3 yuan1
+宜 yi2
+宝 bao3
+实 shi2
+実 shi2
+宠 chong3
+审 shen3
+客 ke4
+宣 xuan1
+室 shi4
+宥 you4
+宦 huan4
+宧 yi2
+宨 tiao3
+宩 shi3
+宪 xian4
+宫 gong1
+宬 cheng2
+宭 qun2
+宮 gong1
+宯 xiao1
+宰 zai3
+宱 zha4
+宲 bao3
+害 hai4 he2
+宴 yan4
+宵 xiao1
+家 jia1 jie5 gu1
+宷 shen3
+宸 chen2
+容 rong2
+宺 huang3
+宻 mi4
+宼 kou4
+宽 kuan1
+宾 bin1 bin4
+宿 su4 xiu3 xiu4
+寀 cai4
+寁 zan3 jie2
+寂 ji4
+寃 yuan1
+寄 ji4
+寅 yin2
+密 mi4
+寇 kou4
+寈 qing1
+寉 que4
+寊 zhen1
+寋 jian3
+富 fu4
+寍 ning2 ning4
+寎 bing4
+寏 huan2
+寐 mei4
+寑 qin3
+寒 han2
+寓 yu4
+寔 shi2
+寕 ning2 ning4
+寖 jin4 qin4
+寗 ning2 ning4
+寘 zhi4
+寙 yu3
+寚 bao3
+寛 kuan1
+寜 ning2 ning4
+寝 qin3
+寞 mo4
+察 cha2
+寠 ju4 lou2
+寡 gua3
+寢 qin3
+寣 hu1
+寤 wu4
+寥 liao2
+實 shi2
+寧 ning2 ning4 zhu4
+寨 zhai4
+審 shen3
+寪 wei3
+寫 xie3
+寬 kuan1
+寭 hui4
+寮 liao2
+寯 jun4
+寰 huan2
+寱 yi4
+寲 yi2
+寳 bao3
+寴 qin4
+寵 chong3
+寶 bao3
+寷 feng1
+寸 cun4
+对 dui4
+寺 si4
+寻 xun2 xin2
+导 dao3 dao4
+寽 lv4
+対 dui4
+寿 shou4
+尀 po3
+封 feng1
+専 zhuan1
+尃 fu1
+射 she4 yi4 ye4
+尅 ke4
+将 jiang1 jiang4 qiang1
+將 jiang1 jiang4 qiang1
+專 zhuan1
+尉 wei4 yu4
+尊 zun1
+尋 xun2 xin2
+尌 shu4
+對 dui4
+導 dao3 dao4
+小 xiao3
+尐 ji1
+少 shao3 shao4
+尒 er3
+尓 er3
+尔 er3
+尕 ga3
+尖 jian1
+尗 shu2
+尘 chen2
+尙 shang4 chang2
+尚 shang4 chang2
+尜 ga2
+尝 chang2
+尞 liao4 liao2
+尟 xian3
+尠 xian3
+尢 you2 wang1
+尣 wang1
+尤 you2
+尥 liao4
+尦 liao4
+尧 yao2
+尨 mang2 meng2 pang2
+尩 wang1
+尪 wang1
+尫 wang1
+尬 ga4
+尭 yao2
+尮 duo4
+尯 kui4 kui3
+尰 zhong3
+就 jiu4
+尲 gan1
+尳 gu3
+尴 gan1
+尵 tui2
+尶 gan1
+尷 gan1
+尸 shi1
+尹 yin3
+尺 chi3 che3
+尻 kao1
+尼 ni2
+尽 jin3
+尾 wei3 yi3
+尿 niao4 sui1
+局 ju2
+屁 pi4
+层 ceng2
+屃 xi4
+屄 bi1
+居 ju1 ji1
+屆 jie4
+屇 tian2
+屈 qu1
+屉 ti4
+届 jie4
+屋 wu1
+屌 diao3
+屍 shi1
+屎 shi3 xi1
+屏 ping2 bing3 bing4
+屐 ji1
+屑 xie4
+屒 chen2
+屓 xi4
+屔 ni2
+展 zhan3
+屖 xi1
+屘 man3
+屙 e1
+屚 lou4
+屛 ping2 bing3 bing4 bing1
+屜 ti4
+屝 fei4
+属 shu3 zhu3
+屟 xie4
+屠 tu2
+屡 lv3
+屢 lv3
+屣 xi3
+層 ceng2
+履 lv3
+屦 ju4
+屧 xie4
+屨 ju4
+屩 jue1
+屪 liao2
+屫 jue2
+屬 shu3 zhu3
+屭 xi4
+屮 che4 cao3
+屯 tun2 zhun1
+屰 ni4
+山 shan1
+屳 xian1
+屴 li4 le4
+屵 xue1
+屸 long2
+屹 yi4
+屺 qi3
+屻 ren4
+屼 wu4
+屽 han4
+屾 shen1
+屿 yu3 xu4
+岀 chu1
+岁 sui4
+岂 qi3 kai3
+岄 yue4
+岅 ban3
+岆 yao3
+岇 ang2
+岈 ya2
+岉 wu4
+岊 jie2
+岋 e4
+岌 ji2
+岍 qian1
+岎 fen1
+岏 yuan2
+岐 qi2
+岑 cen2
+岒 qian2
+岓 qi2
+岔 cha4
+岕 jie4
+岖 qu1
+岗 gang3 gang1
+岘 xian4
+岙 ao4
+岚 lan2
+岛 dao3
+岜 ba1
+岝 zuo4
+岞 zuo4
+岟 yang3
+岠 ju4
+岡 gang1
+岢 ke3
+岣 gou3
+岤 xue4
+岥 bei1 po1 pi2
+岦 li4
+岧 tiao2
+岨 ju1 ju3
+岩 yan2
+岪 fu2
+岫 xiu4
+岬 jia3
+岭 ling2 ling3
+岮 tuo2
+岯 pei1 pei2
+岰 you3
+岱 dai4
+岲 kuang4
+岳 yue4
+岴 qu1
+岵 hu4
+岶 po4
+岷 min2
+岸 an4
+岹 tiao2
+岺 ling2
+岻 chi2
+岽 dong1
+岿 kui1
+峀 xiu4
+峁 mao3
+峂 tong2
+峃 xue2
+峄 yi4
+峆 he1
+峇 ke1 ba1
+峈 luo4
+峉 e1 e4
+峊 fu4 nie4
+峋 xun2
+峌 die2
+峍 lu4
+峎 en1
+峏 er3
+峐 gai1
+峑 quan2
+峒 tong2 dong4
+峓 yi2
+峔 mu3
+峕 shi2
+峖 an1
+峗 wei2
+峘 huan2 hu1
+峙 zhi4 shi4
+峚 mi4
+峛 li3
+峜 ji1
+峝 tong2 dong4
+峞 wei2
+峟 you4
+峡 xia2
+峢 li3
+峣 yao2
+峤 jiao4 qiao2
+峥 zheng1
+峦 luan2
+峧 jiao1
+峨 e2
+峩 e2
+峪 yu4
+峫 ye2
+峬 bu1
+峭 qiao4
+峮 qun1
+峯 feng1
+峰 feng1
+峱 nao2
+峲 li3
+峳 you2
+峴 xian4
+峵 hong2
+島 dao3
+峷 shen1
+峸 cheng2
+峹 tu2
+峺 geng3
+峻 jun4
+峼 hao4
+峽 xia2
+峾 yin1 yin2
+峿 yu3 wu2
+崀 lang4
+崁 kan3
+崂 lao2
+崃 lai2
+崄 xian3
+崅 que4
+崆 kong1
+崇 chong2
+崈 chong2
+崉 ta4
+崋 hua2
+崌 ju1
+崍 lai2
+崎 qi2
+崏 min2
+崐 kun1
+崑 kun1
+崒 zu2 cui4
+崓 gu4
+崔 cui1
+崕 ya2 yai2
+崖 ya2 yai2
+崗 gang3 gang1
+崘 lun2
+崙 lun2
+崚 ling2
+崛 jue2
+崜 duo1
+崝 zheng1
+崞 guo1
+崟 yin2
+崠 dong1 dong4
+崡 han2
+崢 zheng1
+崣 wei3
+崤 xiao2
+崥 pi3
+崦 yan1
+崧 song1
+崨 jie2
+崩 beng1
+崪 zu2 cui4
+崫 jue2
+崬 dong1
+崭 zhan3
+崮 gu4
+崯 yin2
+崱 ze2 ze4
+崲 huang2
+崳 yu2
+崴 wei1
+崵 yang2
+崶 feng1
+崷 qiu2
+崸 dun4
+崹 ti2
+崺 yi3
+崻 zhi4
+崼 shi4
+崽 zai3
+崾 yao3
+崿 e4
+嵀 zhu4
+嵁 kan1
+嵂 lv4
+嵃 yan3
+嵄 mei3
+嵅 han2
+嵆 ji1
+嵇 ji1 xi2
+嵈 huan3
+嵉 ting2
+嵊 sheng4
+嵋 mei2
+嵌 qian4 qian1
+嵍 wu4
+嵎 yu2
+嵏 zong1
+嵐 lan2
+嵑 jue2 he2 jie2
+嵒 yan2
+嵓 yan2
+嵔 wei3 wei4
+嵕 zong1
+嵖 cha2
+嵗 sui4
+嵘 rong2
+嵚 qin1
+嵛 yu2
+嵝 lou3 lv3
+嵞 tu2
+嵟 dui1
+嵠 xi1 ji1 qi1
+嵡 weng1
+嵢 cang1
+嵣 dang1
+嵤 hong2
+嵥 jie2
+嵦 ai2
+嵧 liu2
+嵨 wu3
+嵩 song1
+嵪 qiao1
+嵫 zi1
+嵬 wei2
+嵭 beng1
+嵮 dian1
+嵯 cuo2 ci1
+嵰 qian3
+嵱 yong3
+嵲 nie4
+嵳 cuo2 ci1
+嵴 ji2
+嵷 song3
+嵸 zong1
+嵹 jiang4 qiang2
+嵺 liao2
+嵼 chan3
+嵽 die2 di4
+嵾 cen1
+嵿 ding3
+嶀 tu1
+嶁 lou3 lv3
+嶂 zhang4
+嶃 zhan3
+嶄 zhan3
+嶅 ao2
+嶆 cao2
+嶇 qu1
+嶈 qiang1
+嶉 zui1
+嶊 zui3
+嶋 dao3
+嶌 dao3
+嶍 xi2
+嶎 yu4
+嶏 bo2
+嶐 long2
+嶑 xiang3
+嶒 ceng2
+嶓 bo1
+嶔 qin1
+嶕 jiao1
+嶖 yan3
+嶗 lao2
+嶘 zhan4
+嶙 lin2
+嶚 liao2
+嶛 liao2
+嶜 jin1
+嶝 deng4
+嶞 duo4
+嶟 zun1
+嶠 jiao4 qiao2
+嶡 gui4
+嶢 yao2
+嶣 qiao2
+嶤 yao2
+嶥 jue2
+嶦 zhan1
+嶧 yi4
+嶨 xue2
+嶩 nao2
+嶪 ye4
+嶫 ye4
+嶬 yi2
+嶭 e4 nie4
+嶮 xian3
+嶯 ji2
+嶰 xie4
+嶱 ke3 ge2
+嶲 xi1
+嶳 di4
+嶴 ao4
+嶵 zui3
+嶷 yi2 ni4
+嶸 rong2
+嶹 dao3
+嶺 ling3
+嶻 za2
+嶼 yu3 xu4
+嶽 yue4
+嶾 yin3
+巀 jie1
+巁 li4
+巂 sui3 gui1
+巃 long2
+巄 long2
+巅 dian1
+巆 ying2
+巇 xi1
+巈 ju2
+巉 chan2
+巊 ying3
+巋 kui1
+巌 yan2
+巍 wei1 wei2
+巎 nao2
+巏 quan2
+巐 chao3
+巑 cuan2
+巒 luan2
+巓 dian1
+巔 dian1
+巖 yan2
+巗 yan2
+巘 yan3
+巙 nao2
+巚 yan3
+巛 chuan1 kun1
+巜 gui4 kuai4
+川 chuan1
+州 zhou1
+巟 huang1
+巠 jing1
+巡 xun2
+巢 chao2
+巣 chao2
+巤 lie1
+工 gong1
+左 zuo3
+巧 qiao3
+巨 ju4
+巩 gong3
+巫 wu1 wu2
+差 cha4 chai1
+巯 qiu2
+巰 qiu2
+己 ji3
+已 yi3
+巳 si4
+巴 ba1
+巵 zhi1
+巶 zhao1 zhao4
+巷 xiang4 hang4
+巸 yi2
+巹 jin3
+巺 xun4
+巻 juan4 juan3
+巽 xun4
+巾 jin1
+巿 fu2
+帀 za1
+币 bi4
+市 shi4
+布 bu4
+帄 ding1
+帅 shuai4 shuo4
+帆 fan1
+帇 nie4
+师 shi1
+帉 fen1
+帊 pa4
+帋 zhi3
+希 xi1
+帍 hu4
+帎 dan4
+帏 wei2
+帐 zhang4
+帑 tang3 nu2
+帒 dai4
+帓 ma4
+帔 pei4
+帕 pa4 mo4
+帖 tie1 tie3 tie4
+帗 fu2
+帘 lian2
+帙 zhi4
+帚 zhou3
+帛 bo2
+帜 zhi4
+帝 di4
+帞 mo4
+帟 yi4
+帠 yi4
+帡 ping2
+帢 qia4
+帣 juan4
+帤 ru2
+帥 shuai4 shuo4
+带 dai4
+帧 zheng4
+帨 shui4
+帩 qiao4
+帪 zhen1
+師 shi1
+帬 qun2
+席 xi2
+帮 bang1
+帯 dai4
+帰 gui1
+帱 chou2 dao4
+帲 ping2
+帳 zhang4
+帴 sha1 jian1 jian3
+帵 wan1
+帶 dai4
+帷 wei2
+常 chang2
+帹 sha4
+帺 qi2
+帻 ze2
+帼 guo2
+帽 mao4
+帾 du3
+帿 hou2
+幀 zheng4
+幁 xu1
+幂 mi4
+幃 wei2
+幄 wo4
+幅 fu2
+幆 yi4
+幇 bang1
+幈 ping2
+幊 gong1
+幋 pan2
+幌 huang3
+幍 dao1
+幎 mi4
+幏 jia1 jia4
+幐 teng2
+幑 hui1
+幒 zhong1
+幓 shan1
+幔 man4
+幕 mu4
+幖 biao1
+幗 guo2
+幘 ze2
+幙 mu4
+幚 bang1
+幛 zhang4
+幜 jing3 jiong3
+幝 chan3
+幞 fu2
+幟 zhi4
+幠 hu1
+幡 fan1
+幢 zhuang4 chuang2
+幣 bi4
+幦 mi4
+幧 qiao1
+幨 chan1 chan4
+幩 fen2
+幪 meng2 meng3
+幫 bang1
+幬 chou2 dao4
+幭 mie4
+幮 chu2
+幯 jie2
+幰 xian3
+幱 lan2
+干 gan1 gan4 han2
+平 ping2
+年 nian2
+幵 qian1
+并 bing4 bing1
+幷 bing4 bing1
+幸 xing4
+幹 gan4 han2
+幺 yao1
+幻 huan4
+幼 you4 yao4
+幽 you1
+幾 ji3 ji1
+广 guang3 yan3 an1
+庀 pi3
+庁 ting1
+庂 ze4
+広 guang3
+庄 zhuang1
+庅 mo5
+庆 qing4
+庇 bi4
+庈 qin2
+庉 dun4
+床 chuang2
+庋 gui3
+庌 ya3
+庍 bai4
+庎 jie4
+序 xu4
+庐 lu2
+庑 wu3 wu2
+库 ku4
+应 ying4 ying1
+底 di3 de5
+庖 pao2
+店 dian4
+庘 ya1
+庙 miao4
+庚 geng1
+庛 ci1 ci4
+府 fu3
+庝 tong2
+庞 pang2
+废 fei4
+庠 xiang2
+庡 yi3
+庢 zhi4
+庣 tiao1
+庤 zhi4
+庥 xiu1
+度 du4 duo2
+座 zuo4
+庨 xiao1
+庩 tu2
+庪 gui3 ji3
+庫 ku4
+庬 pang2 mang2
+庭 ting2 ting4
+庮 you3 you2
+庯 bu1
+庰 ding1
+庱 cheng3
+庲 lai2
+庳 bei1 bi3
+庴 ji2
+庵 an1
+庶 shu4
+康 kang1
+庸 yong1 yong2
+庹 tuo3
+庺 song1
+庻 shu4 zhu4 zhe1
+庼 qing3
+庽 yu4
+庾 yu3
+庿 miao4
+廀 sou1
+廁 ce4
+廂 xiang1
+廃 fei4
+廄 jiu4
+廅 he2
+廆 hui4 gui1 wei3
+廇 liu4
+廈 sha4 xia4
+廉 lian2
+廊 lang2
+廋 sou1
+廌 zhi4
+廍 pou3
+廎 qing3
+廏 jiu4
+廐 jiu4
+廑 jin3 qin2
+廒 ao2
+廓 kuo4
+廔 lou2
+廕 yin4 yin1
+廖 liao4
+廗 dai4
+廘 lu4
+廙 yi4
+廚 chu2
+廛 chan2
+廜 tu1
+廝 si1
+廞 xin1
+廟 miao4
+廠 chang3
+廡 wu3 wu2
+廢 fei4
+廣 guang3
+廥 kuai4
+廦 bi4
+廧 qiang2
+廨 xie4 jie4
+廩 lin3
+廪 lin3 bing3 lan3
+廫 liao2
+廬 lu2
+廮 ying2
+廯 xian1
+廰 ting1
+廱 yong1
+廲 li2
+廳 ting1
+廴 yin3
+廵 xun2
+延 yan2
+廷 ting2
+廸 di2
+廹 po4 pai3
+建 jian4
+廻 hui2
+廼 nai3
+廽 hui2
+廾 gong3 gong4 nian4
+廿 nian4
+开 kai1
+弁 bian4 pan2
+异 yi4
+弃 qi4
+弄 nong4 long4
+弅 fen2
+弆 ju3
+弇 yan3 yan1
+弈 yi4
+弉 zang4 zhuang3
+弊 bi4
+弋 yi4
+弌 yi1
+弍 er4
+弎 san1 san4
+式 shi4
+弐 er4
+弑 shi4
+弒 shi4
+弓 gong1
+弔 diao4
+引 yin3
+弖 hu4
+弗 fu2
+弘 hong2
+弙 wu1
+弚 tui2
+弛 chi2 shi3
+弜 jiang4 qiang2
+弝 ba4
+弞 shen3
+弟 di4 ti4
+张 zhang1 zhang4
+弡 jue2
+弢 tao1
+弣 fu3
+弤 di3
+弥 mi2
+弦 xian2
+弧 hu2
+弨 chao1
+弩 nu3
+弪 jing4
+弫 zhen3
+弬 yi2
+弭 mi3
+弮 quan1
+弯 wan1
+弰 shao1
+弱 ruo4
+弲 xuan1
+弳 jing4
+弴 dun1
+張 zhang1 zhang4
+弶 jiang4
+強 qiang2 qiang3 jiang4
+弸 peng2
+弹 dan4 tan2
+强 qiang2 qiang3 jiang4
+弻 bi4
+弼 bi4
+弽 she4
+弾 dan4
+弿 jian3
+彀 gou4
+彂 fa1 fa4 bo1
+彃 bi4
+彄 kou1
+彆 bie4
+彇 xiao1
+彈 dan4 tan2
+彉 kuo4
+彊 qiang2 qiang3 jiang1 jiang4
+彋 hong2
+彌 mi2
+彍 kuo4
+彎 wan1
+彏 jue2
+彐 ji4
+彑 ji4
+归 gui1 kui4
+当 dang1 dang4
+彔 lu4
+录 lu4 lv4
+彖 tuan4
+彗 hui4 sui4
+彘 zhi4
+彙 hui4 wei4
+彚 hui4
+彛 yi2
+彜 yi2
+彝 yi2
+彞 yi2
+彟 huo4
+彠 huo4
+彡 shan1 xian1
+形 xing2
+彣 wen2
+彤 tong2
+彥 yan4
+彦 yan4
+彧 yu4
+彨 chi1
+彩 cai3
+彪 biao1
+彫 diao1
+彬 bin1
+彭 peng2
+彮 yong3
+彯 piao1
+彰 zhang1
+影 ying3
+彲 chi1
+彳 chi4
+彴 zhuo2
+彵 tuo3
+彶 ji2
+彷 pang2 fang3
+彸 zhong1
+役 yi4
+彺 wang2
+彻 che4
+彼 bi3
+彽 chi2
+彾 ling3
+彿 fu2
+往 wang3 wang4
+征 zheng1
+徂 cu2
+徃 wang3 wang4
+径 jing4
+待 dai4 dai1
+徆 xi1
+徇 xun4 xun2
+很 hen3
+徉 yang2
+徊 huai2 hui2
+律 lv4
+後 hou4
+徍 wa1
+徎 cheng3
+徏 zhi4
+徐 xu2
+徑 jing4
+徒 tu2
+従 cong2
+徕 lai2 lai4
+徖 cong2
+得 de2 de5 dei3
+徘 pai2 pei2
+徙 xi3
+徛 ji4
+徜 chang2
+徝 zhi4
+從 cong2 zong4 zong1 cong1
+徟 zhou1
+徠 lai2 lai4
+御 yu4 ya4
+徢 xie4
+徣 jie4
+徤 jian4
+徥 chi2
+徦 jia3
+徧 bian4
+徨 huang2
+復 fu4 fou4
+循 xun2
+徫 wei3
+徬 pang2
+徭 yao2
+微 wei1 wei2
+徯 xi1 xi2
+徰 zheng1
+徱 piao4 biao1
+徲 chi2
+徳 de2 duo2
+徴 zheng1
+徵 zheng1 zhi3
+徶 bie4
+德 de2
+徸 chong1
+徹 che4
+徺 jiao3
+徻 wei4
+徼 jiao4 jiao3 jiao1 yao1 yao2
+徽 hui1
+徾 mei2
+徿 long4
+忀 xiang1
+忁 bao4
+忂 qu2
+心 xin1
+必 bi4
+忆 yi4
+忇 le4
+忈 ren2
+忉 dao1
+忊 ding4
+忋 gai3
+忌 ji4
+忍 ren3
+忎 ren2
+忏 chan4
+忐 tan3
+忑 te4
+忒 tui1
+忓 gan1
+忔 qi4 yi4
+忕 shi4 tai4
+忖 cun3
+志 zhi4
+忘 wang4 wang2
+忙 mang2
+忚 xi1
+忛 fan2
+応 ying1
+忝 tian3
+忞 min2
+忟 min2
+忠 zhong1
+忡 chong1
+忢 wu4
+忣 ji2
+忤 wu3
+忥 xi4
+忦 ye4
+忧 you1
+忨 wan4
+忩 cong1
+忪 zhong1 song1
+快 kuai4
+忬 yu4
+忭 bian4
+忮 zhi4
+忯 qi2
+忰 cui4
+忱 chen2
+忲 tai4
+忳 tun2 zhun1
+忴 qian2
+念 nian4
+忶 hun2
+忷 xiong1
+忸 niu3 nv4
+忹 wang3
+忺 xian1
+忻 xin1
+忼 kang1
+忽 hu1
+忾 kai4
+忿 fen4
+怀 huai2
+态 tai4
+怂 song3
+怃 wu3
+怄 ou4
+怅 chang4
+怆 chuang4
+怇 ju4
+怈 yi4
+怉 bao3
+怊 chao1
+怋 min2
+怌 pei1
+怍 zuo4
+怎 zen3
+怏 yang4
+怐 kou4
+怑 ban4
+怒 nu4
+怓 nao2
+怔 zheng1
+怕 pa4
+怖 bu4
+怗 tie1
+怘 gu4
+怙 hu4
+怚 ju4
+怛 da2
+怜 lian2
+思 si1 si4 sai1
+怞 chou1 you2
+怟 di4
+怠 dai4
+怡 yi2
+怢 tu2 tu1
+怣 you2
+怤 fu1
+急 ji2
+怦 peng1
+性 xing4
+怨 yuan4
+怩 ni2
+怪 guai4
+怫 fu2
+怬 xi4
+怭 bi4
+怮 you1
+怯 qie4
+怰 xuan4
+怱 cong1
+怲 bing3
+怳 huang3
+怴 xu4
+怵 chu4
+怶 pi1
+怷 xi1
+怸 xi1
+怹 tan1
+总 zong3 zong1
+怼 dui4
+怿 yi4
+恀 chi3 shi4
+恁 nen4
+恂 xun2
+恃 shi4
+恄 xi4
+恅 lao3
+恆 heng2
+恇 kuang1
+恈 mu2 mou2
+恉 zhi3
+恊 xie2
+恋 lian4
+恌 tiao1
+恍 huang3
+恎 die2
+恏 hao3
+恐 kong3
+恑 gui3
+恒 heng2
+恓 xi1
+恔 xiao4
+恕 shu4
+恗 kua3
+恘 qiu1
+恙 yang4
+恚 hui4
+恛 hui2
+恜 chi4
+恝 jia2
+恞 yi2
+恟 xiong1
+恠 guai4
+恡 lin4
+恢 hui1
+恣 zi4 ci1
+恤 xu4
+恥 chi3
+恦 xiang4
+恧 nv4
+恨 hen4
+恩 en1
+恪 ke4
+恫 tong1 dong4
+恬 tian2
+恭 gong1
+恮 quan2
+息 xi1
+恰 qia4
+恱 yue4
+恲 peng1
+恳 ken3
+恴 de2
+恵 hui4
+恶 e4 wu4 wu1
+恸 tong4
+恹 yan4
+恺 kai3
+恻 ce4
+恼 nao3
+恽 yun4
+恾 mang2
+恿 yong3
+悀 yong3
+悁 yuan1 juan4
+悂 pi1
+悃 kun3
+悄 qiao3
+悅 yue4
+悆 yu4
+悇 yu4 tu2
+悈 jie4
+悉 xi1
+悊 zhe2
+悋 lin4
+悌 ti4
+悍 han4
+悎 hao4
+悏 qie4
+悐 ti4
+悑 bu4
+悒 yi4
+悓 qian4
+悔 hui3
+悕 xi1
+悖 bei4 bo2
+悗 man2 men4
+悘 yi1
+悙 heng1
+悚 song3
+悛 quan1
+悜 cheng3
+悝 kui1 hui1 li3
+悞 wu4
+悟 wu4
+悠 you1
+悡 li2
+悢 liang4
+患 huan4
+悤 cong1
+悥 yi4 yi1
+悦 yue4
+悧 li4
+您 nin2
+悩 nao3
+悪 e4
+悫 que4
+悬 xuan2
+悭 qian1
+悮 wu4
+悯 min3
+悰 cong2
+悱 fei3
+悲 bei1
+悳 duo2
+悴 cui4
+悵 chang4
+悶 men4 men1
+悷 li4
+悸 ji4
+悹 guan4
+悺 guan4
+悻 xing4
+悼 dao4
+悽 qi1
+悾 kong1
+悿 tian3
+惀 lun2 lun3
+惁 xi1
+惂 kan3
+惃 kun1
+惄 ni4
+情 qing2
+惆 chou2
+惇 dun1
+惈 guo3
+惉 chan1 zhan1
+惊 jing1 liang2
+惋 wan3
+惌 yuan1 yu4
+惍 jin1
+惎 ji4
+惏 lin2 lan2
+惐 yu4
+惑 huo4
+惒 he2
+惓 juan4
+惔 tan2 dan4
+惕 ti4
+惖 ti4
+惗 nie1
+惘 wang3
+惙 chuo4
+惚 hu1 bu1
+惛 hun1
+惜 xi1
+惝 chang3 tang3
+惞 xin1
+惟 wei2
+惠 hui4
+惡 e4 wu4 wu1
+惢 rui3 suo3
+惣 zong3
+惤 jian1
+惥 yong3
+惦 dian4
+惧 ju4
+惨 can3
+惩 cheng2
+惪 de2
+惫 bei4
+惬 qie4
+惭 can2
+惮 dan4
+惯 guan4
+惰 duo4
+惱 nao3
+惲 yun4
+想 xiang3
+惴 zhui4
+惵 die4
+惶 huang2
+惷 chun3
+惸 qiong2
+惹 re3
+惺 xing1
+惻 ce4
+惼 bian3
+惽 hun1
+惾 zong1
+惿 ti2
+愀 qiao3
+愁 chou2
+愂 bei4 bei3
+愃 xuan1 xuan3
+愄 wei1
+愅 ge2
+愆 qian1
+愇 wei3
+愈 yu4
+愉 yu2 tou1
+愊 bi4
+愋 xuan1
+愌 huan4
+愍 min3
+愎 bi4
+意 yi4
+愐 mian3
+愑 yong3
+愒 kai4 qi4
+愓 dang4 shang1
+愔 yin1
+愕 e4
+愖 chen2
+愗 mou4
+愘 ke4
+愙 ke4
+愚 yu2
+愛 ai4
+愜 qie4
+愝 yan3
+愞 nuo4
+感 gan3
+愠 yun4 wen3
+愡 zong3
+愢 sai1
+愣 leng4 leng2
+愤 fen4
+愦 kui4
+愧 kui4
+愨 que4
+愩 gong1
+愪 yun2
+愫 su4
+愬 su4 shuo4
+愭 qi2
+愮 yao2
+愯 song3
+愰 huang3
+愱 ji2
+愲 gu3
+愳 ju4
+愴 chuang4
+愵 ni4
+愶 xie2
+愷 kai3
+愸 zheng3
+愹 yong3
+愺 cao3
+愻 sun4 xun4
+愼 shen4
+愽 bo2
+愾 kai4
+愿 yuan4
+慀 xie2
+慁 hun4
+慂 yong3
+慃 yang3
+慄 li4
+慅 sao1 cao3
+慆 tao1
+慇 yin1
+慈 ci2
+慉 xu4
+慊 qian4 qie4
+態 tai4
+慌 huang1 huang3
+慍 yun4
+慎 shen4
+慏 ming3
+慑 she4 zhe2
+慒 cong2
+慓 piao4
+慔 mo4
+慕 mu4
+慖 guo2
+慗 chi4
+慘 can3
+慙 can2
+慚 can2
+慛 cui2
+慜 min3
+慝 te4 ni4
+慞 zhang1
+慟 tong4
+慠 ao4
+慡 shuang3
+慢 man4
+慣 guan4
+慤 que4
+慥 zao4 cao4
+慦 jiu4
+慧 hui4
+慨 kai3
+慩 lian2
+慪 ou4
+慫 song3
+慬 jin3 jin4 qin2
+慭 yin4
+慮 lv4
+慯 shang1
+慰 wei4
+慱 tuan2
+慲 man2
+慳 qian1
+慴 she4 zhe2
+慵 yong1 yong2
+慶 qing4
+慷 kang1 kang3
+慸 di4
+慹 zhi2 zhe2
+慺 lou2
+慻 juan4
+慼 qi1
+慽 qi1
+慾 yu4
+慿 ping2
+憀 liao2
+憁 cong1 zong3
+憂 you1
+憃 chong1
+憄 zhi4
+憅 tong4
+憆 cheng1 zheng4
+憇 qi4
+憈 qu1
+憉 peng2
+憊 bei4
+憋 bie1
+憌 chun2
+憍 jiao1
+憎 zeng1
+憏 chi4
+憐 lian2
+憑 ping2
+憒 kui4
+憓 hui4
+憔 qiao2
+憕 cheng2
+憖 yin4
+憗 yin4
+憘 xi3
+憙 xi3
+憚 dan4
+憛 tan2
+憜 duo3
+憝 dui4
+憞 dui4
+憟 su4
+憠 jue2
+憡 ce4
+憢 xiao1
+憣 fan2 fan1
+憤 fen4
+憥 lao2
+憦 lao4
+憧 chong1
+憨 han1
+憩 qi4
+憪 xian2
+憫 min3
+憬 jing3
+憭 liao3 liao2
+憮 wu3
+憯 can3
+憰 jue2
+憱 cu4
+憲 xian4
+憳 tan3
+憴 sheng2
+憵 pi1
+憶 yi4
+憷 chu3
+憸 xian1
+憹 nao2
+憺 dan4
+憻 tan3
+憼 jing3
+憽 song1
+憾 han4
+憿 jiao1 ji1 jiao3
+懀 wai4
+懁 huan2 xuan1
+懂 dong3
+懃 qin2
+懄 qin2
+懅 qu2 ju4
+懆 cao3
+懇 ken3
+懈 xie4
+應 ying1 ying4
+懊 ao4
+懋 mao4
+懌 yi4
+懍 lin3
+懎 se4
+懏 jun4
+懐 huai2
+懑 men4
+懒 lan3
+懓 ai4
+懔 lin3
+懕 yan1
+懖 gua1
+懗 xia4
+懘 chi4
+懙 yu3 yu2
+懚 yin4
+懛 dai1
+懜 meng4
+懝 ai4
+懞 meng2
+懟 dui4
+懠 qi2
+懡 mo3
+懢 lan2
+懣 men4
+懤 chou2
+懥 zhi4
+懦 nuo4
+懧 nuo4
+懨 yan1
+懩 yang3
+懪 bo2
+懫 zhi2 zhi4
+懬 kuang4
+懭 kuang4
+懮 you3 you1
+懯 fu1
+懰 liu2
+懱 mie4
+懲 cheng2
+懴 chan4
+懵 meng3 meng2
+懶 lan3
+懷 huai2
+懸 xuan2
+懹 rang4
+懺 chan4
+懻 ji4
+懼 ju4
+懽 huan1
+懾 she4 zhe2
+懿 yi4
+戀 lian4
+戁 nan3
+戂 mi2
+戃 tang3 chang3
+戄 jue2
+戅 gang4 zhuang4
+戆 gang4 zhuang4
+戇 gang4 zhuang4
+戈 ge1
+戉 yue4
+戊 wu4
+戋 jian1
+戌 xu1
+戍 shu4
+戎 rong2
+戏 xi4 xi1 hu1 hui1
+成 cheng2
+我 wo3
+戒 jie4
+戓 ge1
+戔 jian1
+戕 qiang1 qiang2
+或 huo4 yu4
+戗 qiang1 qiang4
+战 zhan4
+戙 dong4
+戚 qi1
+戛 jia2
+戜 die2
+戝 zei2 ze2
+戞 jia2
+戟 ji3
+戠 shi4
+戡 kan1
+戢 ji2
+戣 kui2
+戤 gai4
+戥 deng3
+戦 zhan4
+戧 chuang1 qiang1 qiang4
+戨 ge1
+戩 jian3
+截 jie2
+戫 yu4
+戬 jian3
+戭 yan3 yin3
+戮 lu4
+戯 xi4 xi1 hu1 hui1
+戰 zhan4
+戱 xi4 xi1 hu1 hui1
+戲 xi4 xi1
+戳 chuo1
+戴 dai4
+戵 qu2
+戶 hu4
+户 hu4
+戸 hu4
+戹 e4 ai4
+戺 shi4
+戻 li4
+戼 mao3
+戽 hu4
+戾 li4 lie4
+房 fang2 pang2
+所 suo3
+扁 bian3 pian1 bian4
+扂 dian4
+扃 jiong1 jiong3
+扄 shang3
+扅 yi2
+扆 yi3
+扇 shan4 shan1
+扈 hu4
+扉 fei1
+扊 yan3
+手 shou3
+才 cai2
+扎 zha1 zha2 za1 zha3
+扏 qiu2
+扐 le4
+扑 pu1 bu1
+扒 ba1 pa1 pa2
+打 da3 da2
+扔 reng1 reng4
+払 fu2
+扗 zai4
+托 tuo1
+扙 zhang4
+扚 diao1
+扛 kang2 gang1
+扜 yu1
+扝 ku1 wu1
+扞 han4 gan3
+扟 shen1
+扠 cha1 zha3
+扡 yi3 chi3 tuo1
+扢 gu3 ge1 xi4
+扣 kou4
+扤 wu4
+扥 tuo1
+扦 qian1
+执 zhi2
+扨 ren4
+扩 kuo4
+扪 men2
+扫 sao3 sao4
+扬 yang2
+扭 niu3
+扮 ban4
+扯 che3
+扰 rao3 rou2
+扱 xi1 cha1
+扲 qian2
+扳 ban1 pan1
+扴 jia2
+扵 yu2
+扶 fu2 pu2
+扷 ao4
+扸 xi1
+批 pi1
+扺 zhi3
+扻 zi4 jie2 zhi4
+扼 e4
+扽 dun4 den4
+找 zhao3
+承 cheng2 zheng3
+技 ji4
+抁 yan3
+抂 kuang2
+抃 bian4 pan4
+抄 chao1
+抅 ju1
+抆 wen4 wen3
+抇 hu2 gu3 jue2
+抈 yue4
+抉 jue2
+把 ba3 ba4
+抋 qin4
+抌 zhen3 shen4
+抍 zheng3
+抎 yun3
+抏 wan2 wan4
+抐 nu4
+抑 yi4
+抒 shu1
+抓 zhua1 zhao1
+抔 pou2 bao4
+投 tou2
+抖 dou3
+抗 kang4 kang2
+折 zhe2 she2 zhe1
+抙 pou2 pou1 fu1
+抚 fu3 hu1
+抛 pao1
+抜 ba2
+抝 ao3 niu4
+択 ze2
+抟 tuan2 zhuan1
+抠 kou1
+抡 lun2 lun1
+抢 qiang3 qiang1 cheng1
+护 hu4
+报 bao4
+抦 bing3
+抧 zhi3
+抨 peng1 beng1
+抩 tan1
+抪 pu1
+披 pi1
+抬 tai2
+抭 yao3 you2
+抮 zhen3
+抯 zha1
+抰 yang3
+抱 bao4
+抲 he1
+抳 ni3
+抴 yi4 ye4
+抵 di3
+抶 chi4
+抷 pi1
+抸 za1
+抹 mo3 ma1 mo4
+抺 mei4
+抻 shen4 shen1 chen1
+押 ya1 xia2
+抽 chou1
+抾 qu1 jie2
+抿 min3
+拀 chu4
+拁 jia1
+拂 fu2 bi4
+拃 zhan3 zha4
+拄 zhu3
+担 dan4 dan1 dan3 qie4
+拆 chai1 ca1 che4
+拇 mu3
+拈 nian2 nian1 nian3 dian1
+拉 la1 la2 la3 la4
+拊 fu3
+拋 pao1
+拌 ban4 pan4
+拍 pai1 bo2 po4
+拎 lin1
+拏 na2
+拐 guai3
+拑 qian2
+拒 ju4 ju3
+拓 tuo4 ta4 zhi2
+拔 ba2 bei4
+拕 tuo1
+拖 tuo1
+拗 ao3 ao4 niu4
+拘 ju1 gou1
+拙 zhuo2 zhuo1
+拚 pan4 fan1 fen4 pin1
+招 zhao1 qiao2 shao2
+拜 bai4
+拝 bai4
+拞 di3
+拟 ni3
+拠 ju4
+拡 kuo4
+拢 long3
+拣 jian3
+拥 yong3 yong1
+拦 lan2
+拧 ning2 ning3 ning4
+拨 bo1 fa2
+择 ze2 zhai2
+拪 qian1
+拫 hen2
+括 kuo4 gua1
+拭 shi4
+拮 jie2 jia2
+拯 zheng3
+拰 nin3
+拱 gong3
+拲 gong3
+拳 quan2
+拴 shuan1
+拵 cun2
+拶 zan3 za1
+拷 kao3
+拸 chi3 yi2
+拹 xie2
+拺 ce4
+拻 hui1
+拼 pin1
+拽 zhuai4 ye4 zhuai1
+拾 shi2 jie4 she4
+拿 na2
+挀 bo4
+持 chi2
+挂 gua4
+挃 zhi4
+挄 kuo4
+挅 duo3
+挆 duo3
+指 zhi3
+挈 qie4 qi4
+按 an4
+挊 nong4
+挋 zhen4
+挌 ge2
+挍 jiao4
+挎 kua4 ku1 kou1
+挏 dong4
+挐 ru2 na2 nu2 rao2
+挑 tiao1 tiao3 tao1
+挒 lie4
+挓 zha1
+挔 lv3
+挕 die2
+挖 wa1
+挗 jue2
+挙 ju3
+挚 zhi4
+挛 luan2
+挜 ya4
+挝 zhua1 wo1
+挞 ta4
+挟 xie2 jia1 xia2
+挠 nao2
+挡 dang3 dang4 tang3
+挢 jiao3
+挣 zheng1 zheng4
+挤 ji3
+挥 hui1
+挦 xun2 xian2
+挨 ai1 ai2
+挩 tuo1 shui4
+挪 nuo2 ruo2
+挫 cuo4
+挬 bo2
+挭 geng3
+挮 ti3
+振 zhen4 zhen1 zhen3
+挰 cheng2
+挱 suo1
+挲 suo1
+挳 keng1 qian1
+挴 mei3
+挵 long4 nong4
+挶 ju2
+挷 peng2 beng1 bang4 bang3
+挸 jian3
+挹 yi4
+挺 ting3
+挻 shan1
+挼 nuo4 nuo2 ruo2
+挽 wan3
+挾 xie2 jia1 xia2
+挿 cha1 zha3
+捀 feng1
+捁 jiao3
+捂 wu3
+捃 jun4
+捄 jiu4 jiu1 ju1 qiu2
+捅 tong3
+捆 kun3
+捇 huo4
+捈 tu2
+捉 zhuo1
+捊 pou2
+捋 lv3 le4 luo1
+捌 ba1
+捍 han4
+捎 shao1
+捏 nie1
+捐 juan1 yuan2
+捑 ze2
+捒 song3
+捓 ye2
+捔 jue2
+捕 bu3
+捖 huan2 gua1 wan2
+捗 bu4
+捘 zun4
+捙 yi4
+捚 zhai1
+捛 lv3
+捜 sou1
+捝 tuo1
+捞 lao1
+损 sun3
+捠 bang1
+捡 jian3 lian4
+换 huan4
+捣 dao3
+捥 wan4
+捦 qin2
+捧 peng3
+捨 she3
+捩 lie4 li4
+捪 min2
+捫 men2
+捬 fu3
+捭 bai3
+据 ju4 ju1
+捯 dao3 dao2
+捰 wo3
+捱 ai2
+捲 juan3 quan2
+捳 yue4
+捴 zong3
+捵 chen3 chen1
+捶 chui2
+捷 jie2 qie4
+捸 tu1
+捹 ben4
+捺 na4
+捻 nian3 nie1
+捼 nuo2 ruo2
+捽 zu2 zuo2
+捾 wo4
+捿 xi1
+掀 xian1
+掁 cheng2
+掂 dian1
+掃 sao3 sao4
+掄 lun1 lun2
+掅 qing4
+掆 gang1
+掇 duo2 duo1
+授 shou4
+掉 diao4
+掊 pou2 bao4 fu4 pou3
+掋 di3
+掌 zhang3
+掍 gun3 hun3
+掎 ji3
+掏 tao1
+掐 qia1
+掑 qi2
+排 pai2 pai3 bei4
+掓 shu2
+掔 qian1
+掕 ling4
+掖 ye4 ye1 yi4 ye3
+掗 ya4
+掘 jue2
+掙 zheng1 zheng4
+掚 liang3
+掛 gua4
+掜 yi3 ni3 nie4
+掝 huo4 xu4
+掞 shan4 yan4
+掟 zheng3
+掠 lve4 lve3
+採 cai3
+探 tan4 tan1
+掣 che4
+掤 bing1
+接 jie1
+掦 ti4
+控 kong4 qiang1
+推 tui1
+掩 yan3
+措 cuo4 ze2
+掫 zou1
+掬 ju2 ju1
+掭 tian4
+掮 qian2
+掯 ken4
+掰 bai1
+掱 shou3 pa2
+掲 jie1 qi4
+掳 lu3
+掴 guo2
+掷 zhi2 zhi1 zhi4
+掸 dan3 shan4 shan3 chan2
+掺 chan1 xian1 can4 shan3
+掻 sao1
+掼 guan4
+掽 peng4
+掾 yuan4
+掿 nuo4
+揀 jian3
+揁 zhen1
+揂 jiu1
+揃 jian1 jian3
+揄 yu2 you2
+揅 yan2
+揆 kui2
+揇 nan3
+揈 hong1
+揉 rou2
+揊 pi4
+揋 wei1
+揌 sai1
+揍 zou4 cou4
+揎 xuan1 shuan1
+描 miao2
+提 ti2 di1 di3 shi2
+揑 nie1
+插 cha1
+揓 shi4
+揔 zong3 zong1
+揕 zhen4
+揖 yi1 ji2
+揗 shun3
+揘 heng2
+揙 bian4
+揚 yang2
+換 huan4
+揜 yan3
+揝 zuan4
+揞 an3
+揟 xu1
+揠 ya4
+握 wo4
+揢 ke4
+揣 chuai3 chuai1 chuai4 tuan2 zhui1
+揤 ji2
+揥 ti4 di4
+揦 la2
+揧 la4
+揨 cheng2
+揩 kai1
+揪 jiu1
+揫 jiu1
+揬 tu2
+揭 jie1
+揮 hui1
+揯 geng1
+揰 chong4
+揱 shuo4 xiao1
+揲 she2 tie2 die2 ye4
+揳 xie4 xie2 jia2 xie1
+援 yuan2
+揵 qian2 jian4
+揶 ye2
+揷 cha1
+揸 zha1
+揹 bei1
+揺 yao2
+揽 lan3
+揾 wen4
+揿 qin4
+搀 chan1
+搁 ge1 ge2
+搂 lou3 lou1 lou2
+搃 zong3
+搄 geng1
+搅 jiao3
+搆 gou4
+搇 qin4
+搈 yong3
+搉 que4
+搊 chou1
+搋 chuai1 chi3 cha1
+搌 zhan3
+損 sun3
+搎 sun1
+搏 bo2
+搐 chu4 chou1
+搑 rong3
+搒 beng4 bang4 peng2
+搓 cuo1
+搔 sao1 zhao3
+搕 ke4
+搖 yao2
+搗 dao3
+搘 zhi1
+搙 nu4
+搚 xie2 la1
+搛 jian1
+搜 sou1
+搝 qiu3
+搞 gao3
+搟 xian3
+搠 shuo4
+搡 sang3
+搢 jin4
+搣 mie4
+搤 e4
+搥 chui2
+搦 nuo4
+搧 shan1
+搨 ta4 da1
+搩 jie2
+搪 tang2
+搫 pan2
+搬 ban1
+搭 da1 ta4
+搮 li4
+搯 tao1
+搰 hu2 gu3
+搱 zhi4
+搲 wa1
+搳 xia2 hua2
+搴 qian1
+搵 wen4
+搶 qiang3 qiang1 cheng1
+搷 tian2 shen1
+搸 zhen1
+搹 e4
+携 xi1 xi2 xie2
+搻 nuo4
+搼 quan2
+搽 cha2
+搾 zha4
+搿 ge2
+摀 wu3
+摁 en4
+摂 she4 nie4
+摃 kang2 gang1
+摄 she4 nie4
+摅 shu1
+摆 bai3
+摇 yao2
+摈 bin4
+摉 sou1
+摊 tan1
+摋 sa4
+摌 chan3
+摍 suo1
+摎 liao2 jiu1 liu2
+摏 chong1
+摐 chuang1
+摑 guo2
+摒 bing4
+摓 feng2
+摔 shuai1
+摕 di4
+摖 qi4
+摘 zhai1 zhe2
+摙 lian3
+摚 tang2
+摛 chi1 li2
+摜 guan4
+摝 lu4
+摞 luo4 luo2
+摟 lou3 lou1 lou2
+摠 zong3 zong1
+摡 gai4 xi4
+摢 hu4
+摣 zha1 za1
+摤 chuang3
+摥 tang4
+摦 hua4
+摧 cui1 cuo4
+摨 nai2
+摩 mo2 ma1
+摪 jiang1
+摫 gui1
+摬 ying4
+摭 zhi2 tuo4
+摮 ao2
+摯 zhi4
+摰 nie4
+摱 man2
+摲 shan4 zhan4
+摳 kou1
+摴 shu1
+摵 suo3 she4
+摶 tuan2 zhuan1
+摷 jiao3
+摸 mo1 mo2
+摹 mo2
+摺 zhe2 la1
+摻 chan1 shan3 sen1 can4 xian1
+摼 keng1
+摽 piao1 biao4 biao1 pao1 piao3
+摾 jiang4
+摿 yin1
+撀 gou4
+撁 qian1
+撂 liao4 lve4 liao1 liao2
+撃 ji2
+撄 ying1
+撅 jue1 jue2 gui4
+撆 pie1 pie3
+撇 pie1 pie3
+撈 lao1
+撉 dun1
+撊 xian4
+撋 ruan2 nuo2
+撌 kui4 gui4
+撍 zan3
+撎 yi4
+撏 xun2 xian2
+撐 cheng1
+撑 cheng1
+撒 sa1 sa3
+撓 nao2
+撔 heng4
+撕 si1 xi1
+撖 qian3 han4
+撗 huang2
+撘 da1
+撙 zun3
+撚 nian3
+撛 lin3
+撜 zheng3 cheng2
+撝 hui1
+撞 zhuang4 chuang2
+撟 jiao3
+撠 ji3
+撡 cao1
+撢 dan3 tan4
+撣 dan3 chan2 shan4
+撤 che4
+撥 bo1 fa2
+撦 che3
+撧 jue2 jue1
+撨 xiao1
+撩 liao1 liao2 liao4
+撪 ben4
+撫 fu3 hu1
+撬 qiao4
+播 bo1 bo4 bo3
+撮 cuo1 zuo3
+撯 zhuo2
+撰 zhuan4 suan4 xuan3
+撱 tuo3
+撲 pu1
+撳 qin4
+撴 dun1
+撵 nian3
+撷 xie2
+撸 lu3
+撹 jiao3
+撺 cuan1
+撻 ta4
+撼 han4
+撽 qiao4
+撾 zhua1 wo1
+撿 jian3 lian4
+擀 gan3 han4
+擁 yong1 yong3
+擂 lei2 lei4 lei1
+擃 kuo3
+擄 lu3
+擅 shan4
+擆 zhuo2
+擇 ze2 zhai2
+擈 pu1 bu3
+擉 chuo4 chuo1
+擊 ji1 ji2 ji4 xi2
+擋 dang3 dang4 tang3
+擌 suo3
+操 cao1 cao4
+擎 qing2
+擏 jing4 qing2
+擐 huan4 guan1 xuan1
+擑 jie1 xie2 cha1 sha4
+擒 qin2
+擓 kuai3
+擔 dan1 dan4
+擕 xi1 xi2 xie2
+擖 ge3 ye4
+擗 pi4 pi3
+擘 bo4
+擙 ao4
+據 ju4
+擛 ye4
+擞 sou3 sou4
+擟 mi2
+擠 ji3
+擡 tai2
+擢 zhuo2
+擣 dao3
+擤 xing3
+擥 lan3
+擦 ca1
+擧 ju3
+擨 ye2
+擩 ru3 rui4
+擪 ye4
+擫 ye4
+擬 ni3
+擭 wo4 huo4 hu4
+擮 ji2
+擯 bin4
+擰 ning2 ning3 ning4
+擱 ge1 ge2
+擲 zhi4 zhi2 zhi1
+擳 jie2
+擴 kuo4
+擵 mo2 mi2 ma1
+擶 jian4
+擷 xie2
+擸 lie4 la4
+擹 tan1
+擺 bai3
+擻 sou3 sou4
+擼 lu3
+擽 lve4 li4 luo4
+擾 rao3 rou2
+擿 zhi2 ti4 zhi4
+攀 pan1
+攁 yang3
+攂 lei4 lei2
+攃 sa4
+攄 shu1
+攅 zan3
+攆 nian3
+攇 xian3
+攈 jun4
+攉 huo4 huo1 que4
+攊 li4
+攋 la4
+攌 han4 huan3
+攍 ying2
+攎 lu2
+攏 long3
+攐 qian1
+攑 qian1
+攒 zan3
+攓 qian1
+攔 lan2
+攕 san1 xian1
+攖 ying1
+攗 mei2
+攘 rang4 rang3 ning2 xiang3 rang2
+攙 chan1
+攛 cuan1
+攜 xie2 xi1 xi2
+攝 she4 nie4
+攞 luo3 luo1 lv3
+攟 jun4
+攠 mi2 ma1 mo2
+攡 li2 chi1
+攢 zan3 cuan2 zuan1
+攣 luan2 lian4
+攤 tan1
+攥 zuan4
+攦 li4 xi3
+攧 dian1 die2
+攨 wa1
+攩 dang3 tang3
+攪 jiao3
+攫 jue2
+攬 lan3
+攭 li4
+攮 nang3
+支 zhi1
+攰 gui4
+攱 gui3
+攲 qi1 ji1 yi1
+攳 xin2
+攴 pu1 po1
+攵 sui1
+收 shou1
+攷 kao3 kao2
+攸 you1
+改 gai3
+攺 yi3
+攻 gong1
+攼 gan1
+攽 ban1 bin1
+放 fang4 fang3
+政 zheng4 zheng1
+敀 bo2
+敁 dian1
+敂 kou4
+敃 min3
+敄 wu4 mou4
+故 gu4 gu3
+敆 he2
+敇 ce4
+效 xiao4
+敉 mi3
+敊 chu4
+敋 ge2 guo2
+敌 di2
+敍 xu4
+敎 jiao4 jiao1
+敏 min3
+敐 chen2
+救 jiu4
+敒 zhen4
+敓 duo2
+敔 yu3
+敕 chi4
+敖 ao2 ao4
+敗 bai4
+敘 xu4
+教 jiao4 jiao1
+敚 duo2
+敛 lian4 lian3
+敜 nie4
+敝 bi4
+敞 chang3
+敟 dian3
+敠 duo2
+敡 yi4
+敢 gan3
+散 san4 san3
+敤 ke3
+敥 yan4
+敦 dun1 dui4 diao1 dui1 tuan2 tun2
+敧 qi3
+敨 dou3
+敩 xiao4
+敪 duo2
+敫 jiao4 jiao3
+敬 jing4
+敭 yang2
+敮 xia2 gui1
+敯 min2 hun1
+数 shu4 shu3 cu4 shuo4
+敱 ai2 zhu2
+敲 qiao1
+敳 ai2
+整 zheng3
+敵 di2
+敶 zhen4
+敷 fu1
+數 shu4 shu3 cu4 shuo4
+敹 liao2
+敺 qu1
+敻 xiong4
+敼 xi3
+敽 jiao3
+敿 jiao3
+斀 zhuo2
+斁 yi4 du4
+斂 lian3 lian2 lian4
+斃 bi4
+斄 li4 li2 tai2
+斅 xiao4 jiao3
+斆 xiao4 jiao3
+文 wen2 wen4
+斈 xue2
+斉 qi2
+斊 qi2
+斋 zhai1
+斌 bin1
+斍 jue2
+斎 zhai1
+斐 fei3 fei1
+斑 ban1
+斒 ban1
+斓 lan2
+斔 yu3
+斕 lan2
+斖 wei3
+斗 dou3 dou4
+斘 sheng1
+料 liao4 liao2
+斚 jia3
+斛 hu2
+斜 xie2 xia2 ye2
+斝 jia3
+斞 yu3
+斟 zhen1
+斠 jiao4
+斡 wo4 guan3
+斢 tou3
+斣 chu4
+斤 jin1
+斥 chi4
+斦 yin2
+斧 fu3
+斨 qiang1
+斩 zhan3
+斪 qu2
+斫 zhuo2
+斬 zhan3
+断 duan4
+斮 zhuo2
+斯 si1
+新 xin1
+斱 zhuo2
+斲 zhuo2
+斳 qin2
+斴 lin2
+斵 zhuo2
+斶 chu4
+斷 duan4
+斸 zhu3 zhu2
+方 fang1 feng1 pang2 wang3
+斺 xie4
+斻 hang2
+於 yu2 yu1 wu1
+施 shi1 shi3 yi2 yi4
+斾 pei4
+斿 you2 liu2
+旁 pang2 bang4
+旂 qi2
+旃 zhan1
+旄 mao2
+旅 lv3
+旆 pei4
+旇 pi1
+旈 liu2
+旉 fu1
+旊 fang3
+旋 xuan2 xuan4
+旌 jing1
+旍 jing1
+旎 ni3
+族 zu2 zou4 cou4
+旐 zhao4
+旑 yi3
+旒 liu2
+旓 shao1
+旔 jian4
+旖 yi3
+旗 qi2
+旘 zhi4
+旙 fan1
+旚 piao1
+旛 fan1
+旜 zhan1
+旝 guai4 kuai4
+旞 sui4
+旟 yu2
+无 wu2 mo2
+旡 ji4
+既 ji4 xi4
+旣 ji4 xi4
+旤 huo4
+日 ri4 mi4
+旦 dan4
+旧 jiu4
+旨 zhi3
+早 zao3
+旪 xie2
+旫 tiao1
+旬 xun2
+旭 xu4
+旮 xu4 ga1
+旯 xu4 la2
+旰 gan4 han4
+旱 han4
+旲 tai2
+旳 di4
+旴 xu1
+旵 chan3
+时 shi2
+旷 kuang4
+旸 yang2
+旹 shi2
+旺 wang4
+旻 min2
+旼 min2
+旽 tun1
+旾 chun1 chun3
+旿 wu3
+昀 yun2
+昁 bei4
+昂 ang2
+昃 ze4
+昄 ban3
+昅 jie2
+昆 kun1 hun4
+昇 sheng1
+昈 hu4
+昉 fang3
+昊 hao4
+昋 gui4
+昌 chang1
+昍 xuan1
+明 ming2
+昏 hun1 min3
+昐 fen1
+昑 qin3
+昒 hu1
+易 yi4
+昔 xi1 cuo4 xi2
+昕 xin1
+昖 yan2
+昗 ze4
+昘 fang3
+昙 tan2
+昚 shen4
+昛 ju4
+昜 yang2
+昝 zan3 can3
+昞 bing3
+星 xing1
+映 ying4
+昡 xuan4
+昢 pei3 pei4
+昣 zhen3
+昤 ling1
+春 chun1 chun3
+昦 hao4
+昧 mei4
+昨 zuo2
+昩 mo4
+昪 bian4
+昫 xu3 xu1 xu4
+昬 hun1 min3
+昭 zhao1
+昮 zong4
+是 shi4
+昰 shi4 xia4
+昱 yu4 yi4
+昲 fei4
+昳 die2 yi4
+昴 mao3
+昵 ni4 ni3 zhi4
+昶 chang3 chang4
+昷 wen1 yun4
+昸 dong1
+昹 ai3
+昺 bing3
+昻 ang2
+昼 zhou4
+昽 long2
+显 xian3
+昿 kuang4
+晀 tiao3
+晁 chao2
+時 shi2
+晃 huang3 huang4
+晄 huang3
+晅 xuan1 xian3
+晆 kui2
+晇 xu1 kua1
+晈 jiao3
+晉 jin4
+晊 zhi3
+晋 jin4
+晌 shang3
+晍 tong2
+晎 hong3
+晏 yan4
+晐 gai1
+晑 xiang3
+晒 shai4
+晓 xiao3
+晔 ye1 ye4
+晕 yun1 yun4
+晖 hui1
+晗 han2
+晘 han4
+晙 jun4
+晚 wan3
+晛 xian4
+晜 kun1
+晝 zhou4
+晞 xi1
+晟 sheng4 cheng2 jing1
+晠 sheng2
+晡 bu1
+晢 zhe2 zhe1 xi1 zhi4
+晣 zhe1 zhe2 zhi4
+晤 wu4
+晥 han4
+晦 hui4
+晧 hao4
+晨 chen2
+晩 wan3
+晪 tian3
+晫 zhuo2
+晬 zui4
+晭 zhou3
+普 pu3
+景 jing3 ying3
+晰 xi1
+晱 shan3
+晲 yi3 ni4
+晳 xi4 xi1
+晴 qing2
+晵 qi3
+晶 jing1
+晷 gui3
+晸 zhen3 zheng3
+晹 yi4
+智 zhi4 zhi1
+晻 an3 yan3
+晼 wan3
+晽 lin2
+晾 liang4
+晿 chang1
+暀 wang3 wang4
+暁 xiao3
+暂 zan4
+暄 xuan1
+暅 xuan3 geng4 geng3
+暆 yi2
+暇 xia2 xia4
+暈 yun1 yun4
+暉 hui1
+暊 fu3
+暋 min3 min2
+暌 kui2
+暍 he4 ye1
+暎 ying4
+暏 du3
+暐 wei3
+暑 shu3
+暒 qing2
+暓 mao4
+暔 nan2
+暕 jian3 lan2
+暖 nuan3 xuan1
+暗 an4
+暘 yang2
+暙 chun1
+暚 yao2
+暛 suo3
+暜 jin4
+暝 ming2 ming3
+暞 jiao3
+暟 kai3
+暠 gao3 hao4
+暡 weng3
+暢 chang4
+暣 qi4
+暤 hao4
+暥 yan4
+暦 li4
+暧 ai4
+暨 ji4
+暩 gui4
+暪 men3
+暫 zan4
+暬 xie4
+暭 hao4
+暮 mu4
+暯 mo4
+暰 cong1
+暱 ni4
+暲 zhang1
+暳 hui4
+暴 bao4 pu4 bo2
+暵 han4
+暶 xuan2
+暷 chuan2
+暸 liao2 liao3
+暹 xian1
+暺 dan4
+暻 jing3
+暼 pie1
+暽 lin2
+暾 tun1
+暿 xi3
+曀 yi4
+曁 ji4
+曂 huang4
+曃 tai4 dai4
+曄 ye4
+曅 ye4
+曆 li4
+曇 tan2
+曈 tong2
+曉 xiao3
+曊 fei4
+曋 qin3
+曌 zhao4
+曍 hao4
+曎 yi4
+曏 xiang4 shang3
+曐 xing1
+曑 sen1
+曒 jiao3
+曓 bao4 bo2
+曔 jing4
+曕 yan4
+曖 ai4
+曗 ye4
+曘 ru2
+曙 shu4 shu3
+曚 meng2
+曛 xun1
+曜 yao4
+曝 pu4
+曞 li4
+曟 chen2
+曠 kuang4
+曡 die2
+曣 yan4
+曤 huo4
+曥 lu2
+曦 xi1
+曧 rong2
+曨 long2
+曩 nang3
+曪 luo3
+曫 luan2
+曬 shai4
+曭 tang3
+曮 yan3
+曯 chu2
+曰 yue1
+曱 yue1
+曲 qu1 qu3
+曳 ye4 yi4
+更 geng4 geng1
+曵 ye4
+曶 hu1
+曷 he2
+書 shu1
+曹 cao2
+曺 cao2
+曼 man4 man2
+曽 ceng1
+曾 ceng2 zeng1
+替 ti4
+最 zui4
+朁 can3
+朂 xu4
+會 hui4 kuai4 gui4
+朄 yin4 yin3
+朅 qie4
+朆 fen1
+朇 pi2
+月 yue4
+有 you3 you4
+朊 ruan3
+朋 peng2
+朌 ban1 fen2
+服 fu2 fu4 bi4
+朎 ling2
+朏 fei3 pei4
+朐 qu2
+朒 nv4
+朓 tiao4 tiao3
+朔 shuo4
+朕 zhen4
+朖 lang3
+朗 lang3
+朘 juan1
+朙 ming2
+朚 huang1
+望 wang4
+朜 tun1
+朝 zhao1 chao2 zhu1
+朞 ji1 qi2
+期 qi1 qi2 ji1
+朠 ying1
+朡 zong1
+朢 wang4
+朣 tong2
+朤 lang3
+朦 meng2
+朧 long2 long3
+木 mu4
+朩 deng3
+未 wei4
+末 mo4
+本 ben3
+札 zha2
+朮 shu4 zhu2
+术 shu4 zhu2
+朱 zhu1 shu2
+朲 ren2
+朳 ba1
+朴 pu3 po4 pu2 po1 piao2
+朵 duo3
+朶 duo3
+朷 dao1
+朸 li4 le4
+朹 qiu2 gui3
+机 ji1
+朻 jiu1
+朼 bi3
+朽 xiu3
+朾 ting2 ting1 cheng2
+朿 ci4
+杀 sha1 sa4 shai4 she4
+杂 za2
+权 quan2
+杄 qian1
+杅 yu2
+杆 gan1 gan3
+杇 wu1
+杈 cha1 cha4
+杉 shan1 sha1
+杊 xun2
+杋 fan1
+杌 wu4
+杍 zi3
+李 li3
+杏 xing4
+材 cai2
+村 cun1
+杒 ren4
+杓 shao2 biao1 shuo2
+杔 tuo1
+杕 di4 duo4
+杖 zhang4
+杗 mang2
+杘 chi4 chi1
+杙 yi4
+杚 gu3
+杛 gong1
+杜 du4
+杝 yi2 chi3 li2
+杞 qi3
+束 shu4
+杠 gang1 gang4
+条 tiao2
+来 lai2 lai4
+杧 mang2
+杨 yang2
+杩 ma4 ma3
+杪 miao3
+杫 si4
+杬 yuan2 wan2
+杭 hang2 kang1
+杮 fei4 bei4
+杯 bei1
+杰 jie2
+東 dong1
+杲 gao3
+杳 yao3
+杴 xian1
+杵 chu3
+杶 chun1 qun1
+杷 pa2 ba4
+杸 shu1
+杹 hua4
+杺 xin1
+杻 chou3 niu3
+杼 zhu4 shu4
+杽 chou3
+松 song1
+板 ban3
+枀 song1
+极 ji2
+枂 yue4
+枃 jin4
+构 gou1 gou4
+枅 ji1 jian1
+枆 mao2
+枇 pi2 bi3 bi4
+枈 bi4
+枉 wang3
+枊 ang4
+枋 fang1 bing4
+枌 fen2
+枍 yi4
+枎 fu2 fu1
+枏 nan2
+析 xi1
+枑 hu4
+枒 ya2 ya1
+枓 dou3 zhu3
+枔 xun2
+枕 zhen3 zhen4
+枖 yao1
+林 lin2
+枘 rui4
+枙 e3 e4 e2
+枚 mei2
+枛 zhao4
+果 guo3 ke4 luo3 wo3
+枝 zhi1 qi2
+枞 cong1 zong1
+枟 yun4 yun2
+枡 dou3
+枢 shu1
+枣 zao3
+枥 li4
+枧 jian4 jian3
+枨 cheng2
+枪 qiang1 cheng1
+枫 feng1
+枬 nan2
+枭 xiao1
+枮 xian1
+枯 ku1
+枰 ping2
+枱 yi2 tai2 si4
+枲 xi3
+枳 zhi1 zhi2 zhi3
+枴 guai3
+枵 xiao1
+架 jia4
+枷 jia1
+枸 gou3 gou1 ju3 qu2
+枹 fu1 bao1 fu2
+枺 mo4
+枻 yi4
+枼 ye4
+枽 ye4
+枾 shi4
+枿 nie4
+柀 bi3
+柁 duo4 tuo2 tuo3
+柂 yi2 duo4
+柃 ling2
+柄 bing3 bing4
+柅 ni3
+柆 la1
+柇 he2
+柈 pan2
+柉 fan2
+柊 zhong1
+柋 dai4
+柌 ci2
+柍 yang1
+柎 fu1 fu3 fu4
+柏 bai3 bo2 bo4
+某 mou3
+柑 gan1 qian2
+柒 qi1
+染 ran3
+柔 rou2
+柕 mao4
+柖 zhao1
+柗 song1
+柘 zhe4
+柙 xia2 jia3 ya1
+柚 you4 you2 zhu2
+柛 shen1
+柜 gui4 ju3
+柝 tuo4
+柞 zuo4 ze2 zha4
+柟 nan2
+柠 ning2
+柡 yong3
+柢 di3
+柣 zhi2 die2 zhi4
+柤 zha1 ju1 zu3
+查 cha2 zha1
+柦 dan4
+柧 gu1
+柩 jiu4
+柪 ao1
+柫 fu2
+柬 jian3
+柭 bo1
+柮 duo4
+柯 ke1
+柰 nai4
+柱 zhu4 zhu3
+柲 bi4
+柳 liu3
+柴 chai2 zhai4 zi4
+柵 zha4 ce4 sha4 shan1
+柶 si4
+柷 zhu4
+柸 pei1
+柹 shi4
+柺 guai3
+査 cha2 zha1
+柼 yao3
+柽 jue2 cheng1
+柾 jiu4
+柿 shi4
+栀 zhi1
+栁 liu3
+栂 mei2
+栄 rong2
+栅 zha4 ce4 sha4 shan1
+标 biao1
+栈 zhan4
+栉 jie2 zhi4
+栊 long2
+栋 dong4
+栌 lu2
+栎 li4 lao2 yue4
+栏 lan2 lian4
+栐 yong3
+树 shu4
+栒 xun2 sun3
+栓 shuan1
+栔 qi4
+栕 zhen1
+栖 qi1 xi1
+栗 li4
+栘 yi3 yi2
+栙 xiang2
+栚 zhen4
+栛 li4
+栜 su4 she4
+栝 gua1 kuai4 kuo4 tian4
+栞 kan1
+栟 bing1 ben1
+栠 ren3
+校 xiao4 jiao3 jiao4 xiao2
+栢 bo2 bo4 bai3
+栣 ren3
+栤 bing4
+栥 zi1
+栦 chou2
+栧 yi4
+栨 jie2
+栩 xu3
+株 zhu1
+栫 jian4
+栬 zui4
+栭 er2
+栮 er3
+栯 you3 yu4
+栰 fa2
+栱 gong3
+栲 kao3
+栳 lao3
+栴 zhan1
+栵 li4
+样 yang2 yang4 xiang4
+核 he2 hu2
+根 gen1
+栺 zhi3
+栻 shi4 chi4
+格 ge2 ge1
+栽 zai1 zai4
+栾 luan2
+栿 fu2
+桀 jie2
+桁 heng2 hang2 hang4
+桂 gui4
+桃 tao2
+桄 guang4 guang1
+桅 wei2
+框 kuang4 kuang1
+桇 ru2
+案 an4
+桉 an1 an4
+桊 juan4 quan1 quan2
+桋 yi2
+桌 zhuo1
+桍 ku1
+桎 zhi4 zhi2
+桏 qiong2
+桐 tong2
+桑 sang1
+桒 sang1
+桓 huan2
+桔 jie2 ju2 xie2
+桕 jiu4 gao1
+桖 xue4
+桗 duo4 duo3
+桘 zhui4 chui2 dui1
+桙 yu2 mou2
+桚 zan3
+桜 ying1
+桟 zhan4
+桠 ya2
+桡 nao2 rao2
+桢 zhen1 zheng1
+档 dang3 dang4
+桤 qi1
+桥 qiao2
+桦 hua4
+桧 hui4 kuai4 gui4
+桨 jiang3
+桩 zhuang1 chong1
+桪 xun2 xin2
+桫 suo1
+桬 sha1
+桭 zhen1 chen2
+桮 bei1
+桯 ting1 xing2
+桰 gua1
+桱 jing4
+桲 bo2 po5
+桳 ben4
+桴 fu2
+桵 rui3
+桶 tong3
+桷 jue2
+桸 xi1
+桹 lang2
+桺 liu3
+桻 feng1
+桼 qi1
+桽 wen3
+桾 jun1
+桿 gan3
+梀 cu4
+梁 liang2
+梂 qiu2
+梃 ting3 ting4
+梄 you3
+梅 mei2
+梆 bang1
+梇 long4
+梈 peng1
+梉 zhuang1
+梊 di4
+梋 xuan1
+梌 tu2
+梍 zao4
+梎 ao1 you4
+梏 gu4 jue2
+梐 bi4
+梑 di2
+梒 han2
+梓 zi3
+梔 zhi1
+梕 ren4
+梖 bei4
+梗 geng3
+梘 jian4 jian3
+梙 huan4
+梚 wan3
+梛 nuo2
+梜 jia2 jia1
+條 tiao2
+梞 ji4
+梟 xiao1
+梠 lv3
+梡 hun2 kuan3
+梢 shao1 shao4 xiao1
+梣 cen2 chen2 qin2
+梤 fen2
+梥 song1
+梦 meng4 meng2
+梧 wu2 wu4 yu3
+梨 li2
+梩 li2 si4
+梪 dou4
+梫 cen1 qin1
+梬 ying3 cheng3
+梭 suo1 xun4
+梮 ju2
+梯 ti1 ti2
+械 xie4 jie4
+梱 kun3
+梲 zhuo2
+梳 shu1
+梴 chan1
+梵 fan4
+梶 wei3
+梷 jing4
+梸 li2
+梹 bing1 bin1
+梼 tao2 dao3
+梽 zhi4
+梾 lai2
+梿 lian2
+检 jian3
+棁 zhuo2 tuo1
+棂 ling2
+棃 li2
+棄 qi4
+棅 bing4
+棆 zhun1 lun2
+棇 cong1
+棈 qian4
+棉 mian2
+棊 qi2
+棋 qi2 ji1
+棌 cai3
+棍 gun4 hun4 ao1 gun3
+棎 chan2
+棏 te4
+棐 fei3
+棑 pai2 bai4
+棒 bang4
+棓 pou3 bang4 bei4
+棔 hun1
+棕 zong1
+棖 cheng2
+棗 zao3
+棘 ji2
+棙 li4
+棚 peng2
+棛 yu4
+棜 yu4
+棝 gu4
+棞 hun2
+棟 dong4
+棠 tang2
+棡 gang1
+棢 wang3
+棣 di4 ti4 dai4
+棤 xi2
+棥 fan2
+棦 cheng1
+棧 zhan4
+棨 qi3
+棩 yuan1
+棪 yan3
+棫 yu4
+棬 quan1 quan4
+棭 yi4
+森 sen1
+棯 ren3 nian4
+棰 chui2 duo3
+棱 leng2 leng1 ling2 leng4
+棲 qi1 xi1
+棳 zhuo2
+棴 fu2
+棵 ke1 kuan3 ke3
+棶 lai2
+棷 zou1
+棸 zou1
+棹 zhuo1 zhao4
+棺 guan1 guan4
+棻 fen2 fen1
+棼 fen2 fen1 fen4
+棽 chen1 shen1
+棾 qiong2
+棿 nie4
+椀 wan3
+椁 guo3
+椂 lu4
+椃 hao2
+椄 jie1
+椅 yi3 yi1
+椆 chou2
+椇 ju3
+椈 ju2
+椉 cheng2 sheng4
+椊 zuo2
+椋 liang2
+椌 qiang1
+植 zhi2
+椎 zhui1 chui2
+椏 ya1 ya2
+椐 ju1
+椑 bei1 pi2 pi4
+椒 jiao1
+椓 zhuo2
+椔 zi1 zi4
+椕 bin1
+椖 peng2
+椗 ding4
+椘 chu3
+検 jian3
+椝 gui1
+椞 xi4
+椟 du2
+椠 qian4
+椤 luo2
+椥 zhi1
+椪 peng4
+椫 zhan3 shan4
+椭 tuo3
+椮 sen1 shen1
+椯 duo2
+椰 ye2 ye1
+椱 fou4
+椲 wei3
+椳 wei1
+椴 duan4
+椵 jia3 jia1
+椶 zong1
+椷 jian1 han2
+椸 yi2
+椹 shen4 zhen1
+椺 xi2
+椻 yan4
+椼 yan3
+椽 chuan2
+椾 zhan4 jian1
+椿 chun1
+楀 yu3 ju3
+楁 he2
+楂 zha1 cha2 cha1
+楃 wo4
+楄 pian2
+楅 bi4
+楆 yao1
+楇 huo4
+楈 xu1
+楉 ruo4
+楊 yang2
+楋 la4
+楌 yan2
+楍 ben3
+楎 hun2 hui1
+楏 kui2
+楐 jie4
+楑 kui2 kui3
+楒 si1
+楓 feng1
+楔 xie1 xie4
+楕 tuo3
+楖 zhi4 ji2
+楗 jian4 jian3
+楘 mu4
+楙 mao4
+楚 chu3
+楛 hu4 ku3
+楜 hu2
+楝 lian4
+楞 leng2 leng4
+楟 ting2
+楠 nan2
+楡 yu2
+楢 you2
+楣 mei2
+楤 song3
+楥 xuan4 yuan2
+楦 xuan4
+楧 ying1
+楨 zhen1 zheng1
+楩 pian2
+楪 ye4 die2
+楫 ji2
+楬 jie2 qia4
+業 ye4
+楮 chu3 zhu1
+楯 shun3
+楰 yu2
+楱 cou4 zou4
+楲 wei1
+楳 mei2
+楴 di4
+極 ji2
+楶 jie2
+楷 kai3 jie1
+楸 qiu1
+楹 ying2
+楺 rou2
+楻 heng2
+楼 lou2
+楽 le4
+榀 pin3
+概 gai4 gui4 jie2
+榃 tan2
+榄 lan3
+榅 yun2
+榆 yu2
+榇 chen4
+榈 lv2
+榉 ju3
+榍 xie4
+榎 jia3
+榏 yi4
+榐 zhan3
+榑 fu4 fu2
+榒 nai4
+榓 mi4
+榔 lang2 lang3
+榕 rong2
+榖 gu3
+榗 jian4
+榘 ju3
+榙 ta3
+榚 yao3
+榛 zhen1
+榜 bang3 bang4 beng1 pang2
+榝 sha1
+榞 yuan2
+榟 zi3
+榠 ming2
+榡 su4
+榢 jia4
+榣 yao2
+榤 jie2
+榥 huang3 huang4
+榦 gan4 gan1
+榧 fei3
+榨 zha4
+榩 qian2
+榪 ma4 ma3
+榫 sun3
+榬 yuan2
+榭 xie4
+榮 rong2
+榯 shi2
+榰 zhi1
+榱 cui1
+榲 yun2
+榳 ting2
+榴 liu2
+榵 rong2
+榶 tang2
+榷 que4
+榸 zhai1
+榹 si1
+榺 sheng4
+榻 ta4
+榼 ke4
+榽 xi1
+榾 gu4 gu3
+榿 qi1
+槀 kao3 gao3
+槁 gao3 kao4 gao1
+槂 sun1
+槃 pan2
+槄 tao1
+槅 ge2 he2
+槆 xun2
+槇 dian1
+槈 nou4
+槉 ji2
+槊 shuo4
+構 gou4
+槌 chui2 zhui4 dui1
+槍 qiang1 cheng1
+槎 cha2 cha1 zha1
+槏 qian3
+槐 huai2
+槑 mei2
+槒 xu4 chu4
+槓 gang4
+槔 gao1
+槕 zhuo2 zhuo1
+槖 tuo4 tuo2
+様 yang4
+槙 dian1
+槚 jia3
+槛 jian4 kan3
+槜 zui4
+槟 bin1 bing1
+槠 zhu1
+槢 xi2
+槣 qi3
+槤 lian2
+槥 hui4
+槦 yong2
+槧 qian4
+槨 guo3
+槩 gai4
+槪 gai4
+槫 tuan2
+槬 hua4
+槭 cu4 qi1 se4
+槮 sen1 shen1
+槯 cui1
+槰 beng4
+槱 you3 you2
+槲 hu2
+槳 jiang3 jiang1
+槴 hu4
+槵 huan4
+槶 kui4
+槷 yi4 nie4
+槸 nie4
+槹 gao1
+槺 kang1
+槻 gui1
+槼 gui1
+槽 cao2 zao1
+槾 man2 man4
+槿 jin3 qin2
+樀 di4
+樁 zhuang1 chong1
+樂 le4 yue4 yao4 luo4 liao2
+樃 lang2
+樄 chen2
+樅 cong1 zong1
+樆 li2
+樇 xiu1
+樈 qing2
+樉 shuang3
+樊 fan2 pan2 fan4
+樋 tong1
+樌 guan4
+樍 ji1
+樎 suo1
+樏 lei3 lei2
+樐 lu3
+樑 liang2
+樒 mi4
+樓 lou2 lv2
+樔 chao2 jiao3
+樕 su4
+樖 ke1
+樗 chu1 shu1
+樘 tang2 cheng1
+標 biao1
+樚 lu4
+樛 jiu1
+樜 shu4
+樝 zha1
+樞 shu1
+樟 zhang1
+樠 men2 man2
+模 mo2 mu2
+樢 niao3
+樣 yang4 xiang4
+樤 tiao2
+樥 peng2
+樦 zhu4
+樧 sha1
+樨 xi1
+権 quan2
+横 heng2 heng4 guang1 huang2 huang4
+樫 jian1
+樬 cong1 song1
+樯 qiang2
+樱 ying1
+樲 er4
+樳 xin2
+樴 zhi2
+樵 qiao2
+樶 zui1
+樷 cong1 cong2
+樸 pu2 pu3
+樹 shu4
+樺 hua4
+樻 kui4
+樼 zhen1
+樽 zun1 zun3
+樾 yue4
+樿 zhan3 shan4
+橀 xi1
+橁 xun2 chun1
+橂 dian4
+橃 fa1
+橄 gan3
+橅 mo2 mu2
+橆 wu3
+橇 qiao1 qiao4 cui4
+橈 nao2 rao2
+橉 lin4
+橊 liu2
+橋 qiao2
+橌 xian4
+橍 run4
+橎 fan2
+橏 zhan3 shan3
+橐 tuo2 du4 luo4 tuo4
+橑 lao3 liao2
+橒 yun2
+橓 shun4
+橔 tui2
+橕 cheng1
+橖 tang2
+橗 meng2
+橘 ju2
+橙 cheng2 chen2 deng4
+橚 su4
+橛 jue2
+橜 jue2
+橝 tan1 tan2
+橞 hui4
+機 ji1
+橠 nuo3
+橡 xiang4
+橢 tuo3 duo3
+橣 ning3
+橤 rui3
+橥 zhu1
+橦 chuang2 chong1 tong2
+橧 zeng1
+橨 fen2
+橩 qiong2
+橪 ran3
+橫 heng2 heng4
+橬 cen2
+橭 gu1
+橮 liu3
+橯 lao4
+橰 gao1
+橱 chu2
+橶 ji2
+橷 dou1
+橹 lu3
+橼 yuan2
+橽 ta4
+橾 shu1
+橿 jiang1
+檀 tan2 shan4
+檁 lin3
+檂 nong2
+檃 yin3
+檄 xi2
+檅 sui4
+檆 shan1 sha1
+檇 zui4
+檈 xuan2
+檉 cheng1
+檊 gan4
+檋 ju1 ju2
+檌 zui4
+檍 yi4
+檎 qin2
+檏 pu3 pu2
+檐 yan2 dan1
+檑 lei2 lei4
+檒 feng1
+檓 hui3
+檔 dang4 dang3
+檕 ji4 xi4
+檖 sui4
+檗 bo4 bi4
+檘 bi4
+檙 ding3
+檚 chu3
+檛 zhua1
+檜 gui4 kuai4 hui4
+檝 ji2
+檞 jie3 xie4
+檟 jia3
+檠 qing2 jing4
+檡 zhe4 shi4
+檢 jian3
+檣 qiang2
+檤 dao4
+檥 yi3
+檦 biao3
+檧 song1
+檨 she1
+檩 lin3
+檫 cha2 sa4
+檬 meng2
+檭 yin2
+檮 tao2 dao3
+檯 tai2
+檰 mian2
+檱 qi2 ji1
+檳 bin1 bing1
+檴 huo4
+檵 ji4 qi3
+檶 qian1
+檷 mi2
+檸 ning2
+檹 yi1
+檺 gao3
+檻 jian4 kan3 xian3
+檼 yin4 yin3
+檽 er2 nou4
+檾 qing3 jiong3
+檿 yan3
+櫀 qi2
+櫁 mi4
+櫂 zhao4 zhuo1
+櫃 gui4
+櫄 chun1
+櫅 ji1
+櫆 kui2
+櫇 po2
+櫈 deng4
+櫉 chu2
+櫋 mian2
+櫌 you1
+櫍 zhi4
+櫎 guang4 huang3
+櫏 qian1
+櫐 lei3
+櫑 lei3 lei2
+櫒 sa4
+櫓 lu3
+櫔 li4
+櫕 cuan2
+櫖 lv2
+櫗 mie4
+櫘 hui4
+櫙 ou1
+櫚 lv2
+櫛 jie2 zhi4
+櫜 gao1
+櫝 du2
+櫞 yuan2
+櫟 li4 lao2 yue4
+櫠 fei4
+櫡 zhuo2 zhu4
+櫢 sou3
+櫣 lian2
+櫥 chu2
+櫧 zhu1
+櫨 lu2
+櫩 yan2
+櫪 li4
+櫫 zhu1
+櫬 chen4 qin4 guan4
+櫭 jie2 ji4
+櫮 e4
+櫯 su1
+櫰 huai2
+櫱 nie4
+櫲 yu4
+櫳 long2
+櫴 lai4
+櫶 xian3
+櫸 ju3
+櫹 xiao1
+櫺 ling2
+櫻 ying1
+櫼 jian1
+櫽 yin3
+櫾 you2 you4
+櫿 ying2
+欀 xiang1
+欁 nong2
+欂 bo2
+欃 chan2
+欄 lan2 lian4
+欅 ju3
+欆 shuang1
+欇 she4
+欈 wei2
+欉 cong4
+權 quan2
+欋 qu2
+欎 yu4
+欏 luo2 luo3
+欐 li3 li4
+欑 zan4
+欒 luan2
+欓 dang3
+欔 jue2
+欖 lan3
+欗 lan2
+欘 zhu3 zhu2
+欙 lei2
+欚 li3
+欛 ba4
+欜 nang2
+欝 yu4
+欞 ling2
+欠 qian4 que1
+次 ci4
+欢 huan1
+欣 xin1
+欤 yu2
+欥 yu4
+欦 qian1
+欧 ou1 ou3
+欨 xu1
+欩 chao1
+欪 chu4
+欫 chi1
+欬 kai4 ke2
+欭 yi4
+欮 jue2
+欯 xi2
+欰 xu1
+欱 xia4 he1
+欲 yu4
+欳 kuai4
+欴 lang2
+欵 kuan3
+欶 shuo4
+欷 xi1
+欸 ai3 ai1 ei1 ei4
+欹 yi1 qi1
+欺 qi1
+欻 xu1 chua1 hu1
+欼 chi3
+欽 qin1 qin4 yin2
+款 kuan3 xin1
+欿 kan3
+歀 kuan3
+歁 kan3
+歂 chuan2 chuan3
+歃 sha4 xia2
+歅 yin1 yan1
+歆 xin1
+歇 xie1 ya4
+歈 yu2
+歉 qian4
+歊 xiao1
+歋 yi2
+歌 ge1
+歍 wu1
+歎 tan4
+歏 jin4
+歐 ou1 ou3
+歑 hu1
+歒 ti4
+歓 huan1
+歔 xu1
+歕 pen1 pen4 fen4
+歖 xi1
+歗 xiao4
+歘 xu1 chua1
+歙 xi1 she4 xie2 xi4
+歛 han1 lian3 lian4
+歜 chu4
+歝 yi4
+歞 kan3
+歟 yu2
+歠 chuo4
+歡 huan1
+止 zhi3
+正 zheng4 zheng1
+此 ci3
+步 bu4
+武 wu3
+歧 qi2
+歨 bu4
+歩 bu4
+歪 wai1 wai3
+歫 ju4
+歬 qian2
+歭 chi2
+歮 se4
+歯 chi3
+歰 se4 sha4
+歱 zhong3
+歲 sui4
+歳 sui4
+歴 li4
+歵 cuo4
+歶 yu2
+歷 li4
+歸 gui1 kui4
+歹 dai3 e4 dai1
+歺 dai3
+死 si3
+歼 jian1
+歽 zhe2
+歾 mo4 wen3
+歿 mo4
+殀 yao3 yao1
+殁 mo4 wen3
+殂 cu2
+殃 yang1
+殄 tian3
+殅 sheng1
+殆 dai4
+殇 shang1
+殈 xu4
+殉 xun4
+殊 shu1
+残 can2
+殌 jue2
+殍 piao3 bi4
+殎 qia4
+殏 qiu4
+殐 su4
+殑 qing2 jing4
+殒 yun3
+殓 lian4
+殔 yi4
+殕 fou3
+殖 zhi2 shi4
+殗 ye4
+殘 can2
+殙 hun1
+殚 dan1
+殛 ji2
+殜 ye4 die2
+殞 yun3
+殟 wen1
+殠 chou4
+殡 bin4
+殢 ti4 ni4
+殣 jin4 jin3
+殤 shang1
+殥 yin2
+殦 diao1
+殧 cu4
+殨 hui4
+殩 cuan4
+殪 yi4
+殫 dan1
+殬 du4
+殭 jiang1
+殮 lian4
+殯 bin4
+殰 du2
+殲 jian1
+殳 shu1
+殴 ou1
+段 duan4
+殶 zhu4
+殷 yin1 yan1 yin3
+殸 qing4
+殹 yi4
+殺 sha1 sa4 shai4 she4
+殻 que4 ke2 qiao4
+殼 ke2 qiao4
+殽 yao2 xiao2 xiao4
+殾 jun4
+殿 dian4
+毀 hui3 hui4
+毁 hui3
+毂 gu3
+毃 que4
+毄 ji1
+毅 yi4
+毆 ou1 kou1 qu1
+毇 hui3
+毈 duan4
+毉 yi1
+毊 xiao1
+毋 wu2 mou2
+毌 guan4
+母 mu3 mu2 wu3 wu2
+毎 mei3
+每 mei3 mei4
+毐 ai3
+毑 zuo3 jie3
+毒 du2 dai4
+毓 yu4
+比 bi3 bi4 pi2 pi3
+毕 bi4
+毖 bi4
+毗 pi2
+毘 pi2
+毙 bi4
+毚 chan2
+毛 mao2 mao4
+毞 pu2
+毠 jia1
+毡 zhan1
+毢 sai1
+毣 mu4 mao4
+毤 tuo4
+毥 xun2
+毦 er4 er3
+毧 rong2
+毨 xian3
+毩 ju2
+毪 mu2
+毫 hao2
+毬 qiu2
+毭 dou4
+毯 tan3
+毰 pei2
+毱 ju2
+毲 duo2
+毳 cui4 qiao1 xia1
+毴 bi1
+毵 san1
+毷 mao4
+毸 sui1 sai1
+毹 shu1 yu2 yu1
+毺 yu1
+毻 tuo4
+毼 he2
+毽 jian4
+毾 ta4
+毿 san1
+氀 lv2
+氁 mu2
+氂 mao2 li2
+氃 tong2
+氄 rong3
+氅 chang3
+氆 pu3 bang3
+氇 luo2
+氈 zhan1
+氉 sao4
+氊 zhan1
+氋 meng2
+氌 luo2 lu3
+氍 qu2
+氎 die2
+氏 shi4 zhi1 jing1
+氐 di3 di1 zhi1
+民 min2
+氒 jue2
+氓 mang2 meng2
+气 qi4
+氕 pie1
+氖 nai3
+気 qi4
+氘 dao1
+氙 xian1
+氚 chuan1
+氛 fen1
+氜 ri4
+氝 nei4
+氟 fu2
+氠 shen1
+氡 dong1
+氢 qing1
+氣 qi4 xi4
+氤 yin1 yan2
+氥 xi1
+氦 hai4
+氧 yang3
+氨 an1
+氩 ya4
+氪 ke4
+氫 qing1
+氬 ya4
+氭 dong1
+氮 dan4
+氯 lv4
+氰 qing1 qing2
+氱 yang3
+氲 yun1
+氳 yun1
+水 shui3
+氶 zheng3
+氷 bing1
+永 yong3
+氹 dang4
+氻 le4
+氼 ni4
+氽 tun3 niao4 qiu2
+氾 fan4 fan2 feng3
+氿 gui3
+汀 ting1 ding4 ting4
+汁 zhi1 xie2 shi1
+求 qiu2
+汃 bin1 pa4
+汄 ze4
+汅 mian3
+汆 cuan1
+汇 hui4
+汈 diao1
+汉 han4 yi4
+汊 cha4
+汋 zhuo2 yue4
+汌 chuan4
+汍 wan2
+汎 fan4 feng3
+汏 dai4 da4 tai4
+汐 xi4 xi1
+汑 tuo1
+汒 mang2
+汓 qiu2
+汔 qi4
+汕 shan4 shuan4
+汖 pai4
+汗 han4 han2 gan1
+汘 qian1
+汙 wu1 wu4 wa1 yu1
+汚 wu1 wu4 wa1 yu1
+汛 xun4
+汜 si4
+汝 ru3
+汞 gong3
+江 jiang1
+池 chi2 tuo2 che4
+污 wu1 wu4 wa1 yu1
+汤 tang1 tang4 shang1 yang2
+汥 zhi1
+汦 chi2
+汧 qian1
+汨 mi4
+汩 gu3 yu4 hu2
+汪 wang1 wang3 hong2
+汫 qing4
+汬 jing3
+汭 rui4
+汮 jun1
+汯 hong2
+汰 tai4
+汱 quan3
+汲 ji2
+汳 bian4
+汴 bian4
+汵 gan4
+汶 wen4 men2 wen2 min2
+汷 zhong1
+汸 fang1
+汹 xiong1
+決 jue2
+汻 hang3
+汽 qi4 gai1 yi3
+汾 fen2 pen2 fen1
+汿 xu4
+沀 xu4
+沁 qin4
+沂 yi2 yin2
+沃 wo4
+沄 yun2
+沅 yuan2
+沆 hang2 hang4 kang4
+沇 yan3
+沈 chen2 shen3 tan2
+沉 chen2
+沊 dan4
+沋 you2
+沌 dun4 tun2 zhuan4 chun2
+沍 hu4
+沎 huo4
+沏 qi1 qie1 qie4
+沐 mu4
+沑 rou2
+沒 mei2 mo4
+沓 ta4 da2
+沔 mian3
+沕 wu4 mi4
+沖 chong1
+沗 tian1
+沘 bi3
+沙 sha1 sha4 suo1
+沚 zhi3
+沛 pei4
+沜 pan4
+沝 zhui3
+沞 za1
+沟 gou1
+沠 liu2
+没 mei2 mo4 me5
+沢 ze2
+沣 feng1
+沤 ou4 ou1
+沥 li4
+沦 lun2
+沧 cang1
+沨 feng2 feng1
+沩 wei2
+沪 hu4
+沫 mo4
+沬 mei4 hui4
+沭 shu4
+沮 ju1 ju4 jian1 zu3 ju3
+沯 zan3
+沰 tuo1
+沱 tuo2 duo4 chi2
+沲 tuo2 duo4
+河 he2
+沴 li4
+沵 mi3 mi2 ni3
+沶 yi2
+沷 fa1
+沸 fei4 fu2
+油 you2 you4
+沺 tian2
+治 zhi4 chi2 yi2
+沼 zhao3
+沽 gu1 gu3
+沾 zhan1 tian1 tie1 dian4 chan1
+沿 yan2 yan4
+泀 si1
+況 kuang4
+泂 jiong3
+泃 ju4 ju1
+泄 xie4 yi4
+泅 qiu2 you1
+泆 yi1 yi4
+泇 jia1
+泈 zhong1
+泉 quan2
+泊 bo2 po2 po1 po4
+泋 hui4
+泌 mi4 bi4
+泍 ben1
+泎 zhuo2
+泏 chu4
+泐 le4
+泑 you3 you1
+泒 gu1
+泓 hong2
+泔 gan1 han4
+法 fa3
+泖 mao3 mao2 liu3
+泗 si4
+泘 hu1
+泙 ping2 peng1
+泚 ci3
+泛 fan4 fan2 feng3 fa2
+泜 chi2 zhi1 di4 zhi4
+泝 su4
+泞 ning4 zhu3 zhu4
+泟 cheng1
+泠 ling2 ling3
+泡 pao4 pao2 pao1
+波 bo1 bei1 bi4
+泣 qi4 li4 se4
+泤 si4
+泥 ni2 ni4 ni3 nie4 ning4
+泦 ju2
+泧 yue4
+注 zhu4 zhou4
+泩 sheng1
+泪 lei4
+泫 xuan4 xuan2 juan1
+泬 xue4 jue2
+泭 fu1 fu2
+泮 pan4
+泯 min3 mian4
+泰 tai4
+泱 yang1 yang3
+泲 ji3
+泳 yong3
+泴 guan4
+泵 beng4 liu2 pin4
+泶 xue2
+泷 long2 shuang1
+泸 lu2
+泺 bo2 luo4 po1
+泻 xie4
+泼 po1 bo1
+泽 ze2 duo2 shi4 yi4
+泾 jing1
+泿 yin2
+洀 zhou1 pan2
+洁 ji2 jie2
+洂 yi4
+洃 hui1
+洄 hui2 hui4
+洅 zui3
+洆 cheng2
+洇 yin1 yan1 ye1
+洈 wei2
+洉 hou4
+洊 jian4
+洋 yang2 xiang2 yang3
+洌 lie4
+洍 si4
+洎 ji4
+洏 er2
+洐 xing2
+洑 fu2 fu4
+洒 sa3 cui3 xi3 xian3 sen3 xun4
+洓 suo3
+洔 zhi3
+洕 yin1
+洖 wu2
+洗 xi3 xian3
+洘 kao3
+洙 zhu1
+洚 jiang4 hong2
+洛 luo4
+洝 an4
+洞 dong4 tong2
+洟 yi2 ti4
+洠 mou2
+洡 lei3
+洢 yi1
+洣 mi3
+洤 quan2
+津 jin1
+洦 mo4
+洧 wei3
+洨 xiao2
+洩 xie4
+洪 hong2
+洫 xu4 yi4
+洬 shuo4
+洭 kuang1
+洮 tao2 yao2 dao4 tao1
+洯 qie4 jie2
+洰 ju4
+洱 er3
+洲 zhou1
+洳 ru4 ru2
+洴 ping2
+洵 xun2 xuan4
+洶 xiong1
+洷 zhi4
+洸 guang1 huang2
+洹 huan2
+洺 ming2
+活 huo2 guo1
+洼 wa1 gui1
+洽 qia4 he2 xia2
+派 pai4 mai4 bai4 pa1
+洿 wu1
+浀 qu3
+流 liu2
+浂 yi4
+浃 jia2 jia1
+浄 jing4
+浅 qian3
+浆 jiang1 jiang4
+浇 jiao1 ao4
+浈 cheng2 zhen1
+浉 shi1
+浊 zhuo2
+测 ce4
+浍 kuai4
+济 ji4 ji3
+浏 liu2
+浐 chan3
+浑 hun2 hun4 gun3
+浒 hu3
+浓 nong2
+浔 xun2
+浕 jin4
+浖 lie4
+浗 qiu2
+浘 wei3
+浙 zhe4
+浚 jun4 xun4 cun2
+浛 han4 han2
+浜 bang1 bin1
+浝 mang2
+浞 zhuo2
+浟 you2 di2
+浠 xi1
+浡 bo2
+浢 dou4
+浣 huan4 wan3 guan3
+浤 hong2
+浥 yi4 ya4
+浦 pu3
+浧 ying3
+浨 lan3
+浩 hao4 ge2 gao3
+浪 lang4 lang2
+浫 han3
+浬 li3
+浭 geng1
+浮 fu2
+浯 wu2
+浰 lian4 li4
+浱 chun2
+浲 feng2
+浳 yi4
+浴 yu4
+浵 tong2
+浶 lao2
+海 hai3
+浸 jin4 qin1
+浹 jia2 jia1
+浺 chong1
+浻 weng3
+浼 mei3
+浽 sui1
+浾 cheng1
+浿 pei4
+涀 xian4
+涁 shen4
+涂 tu2
+涃 kun4
+涄 pin1
+涅 nie4
+涆 han4
+涇 jing1 qing3
+消 xiao1
+涉 she4 die2
+涊 nian3 ren3 nian4 lian3
+涋 tu1
+涌 yong3 chong1
+涍 xiao4
+涎 xian2 yan4 dian4
+涏 ting3
+涐 e2
+涑 su4 sou1 shu4
+涒 tun1
+涓 juan1 yuan4 xuan4
+涔 cen2 qian2 zan4
+涕 ti4
+涖 li4
+涗 shui4
+涘 si4
+涙 lei4
+涚 shui4
+涛 tao1 tao2
+涜 du2
+涝 lao4 lao2
+涞 lai2
+涟 lian2
+涠 wei2
+涡 wo1 guo1
+涢 yun2
+涣 huan4
+涤 di2
+润 run4
+涧 jian4
+涨 zhang3 zhang4
+涩 se4
+涪 fu2 pou2
+涫 guan4
+涬 xing4
+涭 shou4
+涮 shuan4 shua1
+涯 ya2
+涰 chuo4
+涱 zhang4
+液 ye4 yi4 shi4
+涳 kong1
+涴 wo4 wan3
+涵 han2 han4
+涶 tuo1
+涷 dong1 dong4
+涸 he2 hao4
+涹 wo1
+涺 ju1
+涻 gan4
+涼 liang2 liang4
+涽 hun1
+涾 ta4
+涿 zhuo1 zhuo2
+淀 dian4
+淁 qie4
+淂 de2
+淃 juan4
+淄 zi1
+淅 xi1
+淆 yao2 xiao2
+淇 qi2
+淈 gu3
+淉 guo3
+淊 han4 yan1 yan3 han2
+淋 lin2 lin4
+淌 tang3 chang4 chang3
+淍 zhou1
+淎 peng3
+淏 hao4
+淐 chang1
+淑 shu2 shu1 chu4
+淒 qi1
+淓 fang1
+淔 chi4
+淕 lu4
+淖 nao4 chuo4 zhuo1 zhao4
+淗 ju2
+淘 tao2
+淙 cong2 shuang4
+淚 lei4 li4
+淛 zhi4 zhe4
+淜 peng2 ping2
+淝 fei2
+淞 song1 song4
+淟 tian3
+淠 pi4 pei4
+淡 dan4 tan2 yan3 yan4
+淢 yu4 xu4
+淣 ni2
+淤 yu1
+淥 lu4
+淦 gan4
+淧 mi4
+淨 jing4
+淩 ling2
+淪 lun2 lun3 guan1
+淫 yin2 yan4 yao2
+淬 cui4 zu2
+淭 qu2
+淮 huai2
+淯 yu4
+淰 nian3 shen3 na4 nian4 lian3
+深 shen1
+淲 piao2
+淳 chun2 zhun1 zhun3
+淴 wa4 hu1
+淵 yuan1
+淶 lai2
+混 hun4 hun3 hun2 gun3 kun1
+淸 qing1
+淹 yan1 yan3
+淺 qian3 jian1 jian4 can2 zan4
+添 tian1 tian4
+淼 miao3
+淽 zhi3
+淾 yin3
+淿 mi4
+渀 ben1
+渁 yuan1
+渂 wen4
+渃 re4 ruo4
+渄 fei1
+清 qing1 qing4
+渆 yuan1
+渇 ke3
+済 ji4
+渉 she4 die2
+渊 yuan1
+渌 lu4
+渍 zi4
+渎 du2 dou4
+渐 jian4 jian1 chan2 qian2
+渑 min3 mian3 sheng2
+渒 pi4
+渔 yu2
+渕 yuan1
+渖 shen3
+渗 shen4 qin1
+渘 rou2
+渙 huan4 hui4
+渚 zhu3
+減 jian3
+渜 nuan3
+渝 yu2
+渞 qiu2
+渟 ting2
+渠 qu2 ju4
+渡 du4
+渢 feng2 feng1
+渣 zha1
+渤 bo2
+渥 wo4 ou4 wu1
+渦 wo1 guo1
+渧 di4
+渨 wei1 wei3
+温 wen1 yun4
+渪 ru2
+渫 xie4 die2 zha2 yi4 qie4
+測 ce4
+渭 wei4
+渮 ge1
+港 gang3 hong4
+渰 yan3 yan1
+渱 hong2
+渲 xuan4
+渳 mi3 er3
+渴 ke3 he2 jie2 kai4
+渵 mao2
+渶 ying1
+渷 yan3
+游 you2 liu2
+渹 hong1 qing4
+渺 miao3
+渻 xing3 sheng4
+渼 mei3
+渽 zai1
+渾 hun2 hun4 gun3
+渿 nai4
+湀 kui2
+湁 shi2
+湂 e4
+湃 pai4 ba2
+湄 mei2
+湅 lian4
+湆 qi4
+湇 qi4
+湈 mei2
+湉 tian2
+湊 cou4
+湋 wei2
+湌 can1
+湍 tuan1 zhuan1
+湎 mian3
+湏 hui4
+湐 mo4
+湑 xu3 xu1
+湒 ji2
+湓 pen2 pen4
+湔 jian1 jian4 zan4 zhan3
+湕 jian3
+湖 hu2
+湗 feng4
+湘 xiang1
+湙 yi4
+湚 yin4
+湛 zhan4 chen2 dan1 jian1 tan2 jin4
+湜 shi2
+湝 jie1
+湞 cheng2 zhen1 cheng1
+湟 huang2 kuang4
+湠 tan4
+湡 yu2
+湢 bi4
+湣 min3 hun1
+湤 shi1
+湥 tu2
+湦 sheng1
+湧 yong3
+湨 qu4 ju2
+湩 zhong4 dong4
+湫 jiao3 jiu4 jiu1 qiu1 qiu4
+湬 jiao3
+湮 yan1 yin1
+湯 tang1 tang4 shang1 yang2
+湰 long2
+湱 huo4
+湲 yuan2
+湳 nan3
+湴 ban4
+湵 you3
+湶 quan2
+湷 chui2
+湸 liang4
+湹 chan2
+湺 yan2
+湻 chun2 zhun1
+湼 nie4
+湽 zi1
+湾 wan1
+湿 shi1 qi4
+満 man3
+溁 ying2
+溃 kui4
+溅 jian4 jian1
+溆 xu4
+溇 lv3 lou2
+溈 gui1 wei2
+溉 gai4 xie4
+溌 po1
+溍 jin4
+溎 gui4
+溏 tang2
+源 yuan2
+溑 suo3
+溒 yuan2
+溓 lian2 nian2 lian3
+溔 yao3
+溕 meng4
+準 zhun3
+溗 sheng2
+溘 ke4 kai4
+溙 tai4
+溚 da2
+溛 wa1
+溜 liu1 liu4 liu2
+溝 gou1 gang3 kou4
+溞 sao1
+溟 ming2 ming3 mi4
+溠 zha4 zha1
+溡 shi2
+溢 yi4
+溣 lun2
+溤 ma3
+溥 pu3 fu1 bu4 bo2 po4
+溦 wei2
+溧 li4
+溨 cai2
+溩 wu4
+溪 xi1 qi1
+溫 wen1
+溬 qiang1
+溭 ze2 ce4
+溮 shi1
+溯 su4 shuo4
+溰 yi1
+溱 zhen1 qin2
+溲 sou1 sou3 shao1
+溳 yun2
+溴 xiu4
+溵 yin1
+溶 rong2
+溷 hun4 hun2
+溸 su4
+溹 su4 suo4
+溺 ni4 niao4
+溻 ta4 ta1
+溼 shi1 qi4
+溽 ru4
+溾 wei1
+溿 pan4
+滀 chu4 xu4
+滁 chu2
+滂 pang1
+滃 weng3 weng1
+滄 cang1
+滅 mie4
+滆 he2 ge2
+滇 dian1 tian2 zhen1
+滈 hao4
+滉 huang3 huang4
+滊 xi4
+滋 zi1 ci2
+滌 di2
+滍 zhi3 zhi4
+滎 xing2 ying1 ying2
+滏 fu3
+滐 jie2
+滑 hua2 gu3
+滒 ge1
+滓 zi3
+滔 tao1
+滕 teng2
+滖 sui1
+滗 bi3 bi4
+滘 jiao4
+滙 hui4
+滚 gun3
+滛 yin2 yan4 yao2
+滜 gao1 ze4 hao2
+滝 long2 shuang1
+滞 zhi4
+滟 yan4
+滠 she4
+满 man3 men4
+滢 ying4 ying2
+滣 chun2
+滤 lv4
+滥 lan4
+滦 luan2
+滨 bin1
+滩 tan1
+滪 yu4
+滫 sou3 xiu1 xiu3
+滬 hu4
+滭 bi4
+滮 biao1
+滯 zhi4 chi4
+滰 jiang3
+滱 kou4
+滲 shen4 qin1 sen1 lin2
+滳 shang1
+滴 di1
+滵 mi4
+滶 ao2
+滷 lu3
+滸 hu3 xu3
+滹 hu1 hu3
+滺 you2 di2
+滻 chan3
+滼 fan4
+滽 yong2 rong2
+滾 gun3
+滿 man3 men4
+漀 qing4
+漁 yu2
+漂 piao1 piao3 piao4 biao1
+漃 ji2
+漄 ya2
+漅 jiao3
+漆 qi1
+漇 xi3
+漈 ji4
+漉 lu4
+漊 lv3 lou2
+漋 long2
+漌 jin3
+漍 guo2
+漎 cong2 song3
+漏 lou4 lou2
+漐 zhi2
+漑 gai4
+漒 qiang2
+漓 li2
+演 yan3 yan4
+漕 cao2 cao4
+漖 jiao4
+漗 cong1
+漘 chun2 qun2
+漙 tuan2
+漚 ou4 ou1
+漛 teng2
+漜 ye3
+漝 xi2
+漞 mi4
+漟 tang2
+漠 mo4
+漡 shang1
+漢 han4 tan1
+漣 lian2 lan2
+漤 lan3
+漥 wa1
+漦 li2
+漧 qian2 gan1
+漨 feng2
+漩 xuan2 xuan4
+漪 yi1
+漫 man4 man2
+漬 zi4 se4 qi4
+漭 mang3
+漮 kang1
+漯 ta4 luo4 lei3
+漰 peng1
+漱 shu4 sou4
+漲 zhang3 zhang4 zhang1
+漳 zhang1
+漴 chong2
+漵 xu4
+漶 huan4
+漷 kuo4
+漸 jian4 chan2 jian1 qian2
+漹 yan1
+漺 chuang3
+漻 liao2 liu2
+漼 cui3
+漽 ti2
+漾 yang4 yang2
+漿 jiang1 jiang4
+潀 cong2
+潁 ying3
+潂 hong2
+潃 xun2
+潄 shu4 sou4
+潅 guan4 huan4
+潆 ying2
+潇 xiao1
+潊 xu4
+潋 lian4
+潌 zhi4
+潍 wei2
+潎 pi4 pie1
+潏 jue2 yu4
+潐 jiao4
+潑 po1 bo1
+潒 dang4
+潓 hui4
+潔 jie2
+潕 wu3
+潖 pa2
+潗 ji2
+潘 pan1 pan2 fan1 pan4 bo1
+潙 gui2 wei2 gui1
+潚 xiao1
+潛 qian2
+潜 qian2
+潝 xi1 xi4
+潞 lu4
+潟 xi4
+潠 sun4 xun4 xuan4
+潡 dun4
+潢 huang2 huang3 huang4 guang1
+潣 min3
+潤 run4
+潥 su4
+潦 lao3 lao4 lao2 liao2 liao3
+潧 zhen1
+潨 zhong1
+潩 yi4
+潪 di2
+潫 wan1
+潬 dan4 shan4
+潭 tan2 xun2 yin3 dan4
+潮 chao2
+潯 xun2 yin2
+潰 kui4 xie4
+潲 shao4
+潳 tu2
+潴 zhu1
+潵 san4 sa3
+潶 hei1
+潷 bi3 bi4
+潸 shan1
+潹 chan2
+潺 chan2
+潻 shu3
+潼 tong2 chong1 zhong1
+潽 pu3
+潾 lin2
+潿 wei2
+澀 se4
+澁 se4
+澂 cheng2
+澃 jiong4
+澄 cheng2 deng4
+澅 hua4
+澆 jiao1 ao4 nao4
+澇 lao4 lao2
+澈 che4
+澉 gan3 han4
+澊 cun1
+澋 heng4 jing3
+澌 si1 xi1
+澍 shu4 zhu4
+澎 peng2 peng1
+澏 han4
+澐 yun2
+澑 liu4 liu1 liu2
+澒 hong4 hong3 gong3
+澓 fu2
+澔 hao4
+澕 he2
+澖 xian1
+澗 jian4
+澘 shan1
+澙 xi4
+澜 lan2
+澞 yu2
+澟 lin3
+澠 mian3 sheng2 min3
+澡 zao3 cao1
+澢 dang1
+澣 huan3 huan4 han4 wan3 guan3
+澤 ze2 duo2 shi4 yi4
+澥 xie4
+澦 yu4
+澧 li3
+澨 shi4
+澩 xue2 xiao4
+澪 ling2
+澫 man4
+澬 zi1
+澭 yong1
+澮 kuai4 hui4 hua2
+澯 can4
+澰 lian4
+澱 dian4
+澲 ye4
+澳 ao4 yu4
+澴 huan2
+澵 zhen1
+澶 chan2 dan4 zhan1
+澷 man4
+澸 dan3
+澹 dan4 dan2 shan4 tan2 dan1
+澺 yi4
+澻 sui4
+澼 pi4
+澽 ju4
+澾 ta4
+澿 qin2
+激 ji1 jiao4 jiao1
+濁 zhuo2
+濂 lian2 xian3
+濃 nong2
+濄 guo1 wo1
+濅 jin4
+濆 fen2 fen4 pen1
+濇 se4
+濈 ji2
+濉 sui1
+濊 hui4 huo4 wei4
+濋 chu3
+濌 ta4
+濍 song1
+濎 ding3 ting4
+濐 zhu3
+濑 lai4
+濒 bin1
+濓 lian2
+濔 mi3 mi2 ni3
+濕 shi1 qi4 ta4 xi2
+濖 shu4
+濗 mi4
+濘 ning4 ning2 ni4
+濙 ying2 ying4
+濚 ying2
+濛 meng2
+濜 jin4
+濝 qi2
+濞 pi4 bi4
+濟 ji4 ji3 qi2
+濠 hao2
+濡 ru2 nuan2 ruan3 er2 nuo4
+濢 zui3
+濣 wo4
+濤 tao1 tao2 chao2 shou4 dao4
+濥 yin4
+濦 yin3 xi1 yin1
+濧 dui4
+濨 ci2
+濩 huo4 hu4
+濪 jing4
+濫 lan4 jian4 lan3 lan2
+濬 jun4
+濭 ai4
+濮 pu2 pu1
+濯 zhuo2 zhao4 shuo4
+濰 wei2
+濱 bin1
+濲 gu3
+濳 qian2
+濴 xing2 ying2
+濶 kuo4
+濷 fei4
+濺 jian4 jian1 zan4
+濻 wei3 dui4
+濼 luo4 bo2 po1 li4
+濽 zan4 cuan2 qian2 za1
+濾 lv4
+濿 li4
+瀀 you1
+瀁 yang4 yang3
+瀂 lu3
+瀃 si4
+瀄 jie2
+瀅 ying4 jiong1 ying2
+瀆 du2 dou4
+瀇 wang3
+瀈 hui1
+瀉 xie4
+瀊 pan2
+瀋 shen3 chen4 pan2
+瀌 biao1
+瀍 chan2
+瀎 mo4
+瀏 liu2 liu1
+瀐 jian1
+瀑 pu4 bao4 bo2
+瀒 se4
+瀓 cheng2
+瀔 gu3
+瀕 bin1
+瀖 huo4
+瀗 xian4
+瀘 lu2
+瀙 qin1 qin4
+瀚 han4
+瀛 ying2
+瀜 yong1 rong2
+瀝 li4
+瀞 jing4
+瀟 xiao1
+瀠 ying2
+瀡 sui3
+瀢 wei2
+瀣 xie4
+瀤 huai2
+瀥 hao4
+瀦 zhu1
+瀧 long2 shuang1
+瀨 lai4
+瀩 dui4
+瀪 fan2
+瀫 hu2
+瀬 lai4
+瀯 ying2
+瀰 mi2 mi3
+瀱 ji4
+瀲 lian4
+瀳 jian4
+瀴 ying3 ying1 ying4
+瀵 fen4
+瀶 lin2
+瀷 yi4
+瀸 jian1
+瀹 yue4 yao4
+瀺 chan2
+瀻 dai4
+瀼 rang2 rang4
+瀽 jian3
+瀾 lan2
+瀿 fan2
+灀 shuang4
+灁 yuan1
+灂 zhuo2 jiao4
+灃 feng1
+灄 she4 ni4
+灅 lei3
+灆 lan2
+灇 cong2
+灈 qu2
+灉 yong1
+灊 qian2
+灋 fa3
+灌 guan4 huan4
+灍 que4
+灎 yan4
+灏 hao4
+灑 sa3 li2 xian3 xi3 shi1
+灒 zan4
+灓 luan2
+灔 yan4
+灕 li2
+灖 mi3
+灗 shan4
+灘 tan1 han4 nan4
+灙 dang3
+灚 jiao3
+灛 chan3
+灝 hao4
+灞 ba4
+灟 zhu2
+灠 lan3
+灡 lan2
+灢 nang3
+灣 wan1
+灤 luan2
+灥 xun2
+灦 xian3
+灧 yan4
+灨 gan3 gan4 gong4
+灩 yan4
+灪 yu4
+火 huo3 huo1
+灬 biao1 hou3
+灭 mie4
+灮 guang1
+灯 deng1
+灰 hui1
+灱 xiao1
+灲 xiao1
+灴 hong2
+灵 ling2 ling4
+灶 zao4
+灷 zhuan4
+灸 jiu3
+灹 zha4
+灺 xie4
+灻 chi4
+灼 zhuo2
+災 zai1
+灾 zai1
+灿 can4
+炀 yang2 yang4
+炁 qi4
+炂 zhong1
+炃 fen2
+炄 niu3
+炅 jiong3 geng3 gui4
+炆 wen2
+炇 po4
+炈 yi4
+炉 lu2
+炊 chui1
+炋 pi1
+炌 kai4
+炍 pan4
+炎 yan2 yan4 tan2
+炏 kai4
+炐 pang4
+炑 mu4
+炒 chao3
+炓 liao4
+炔 gui4 xue4 que1 geng3
+炕 kang4 hang1
+炖 dun4 tun1 tun2
+炗 guang1
+炘 xin1
+炙 zhi4
+炛 guang1 guang4
+炜 wei3
+炝 qiang4
+炟 da2
+炠 xia2
+炡 zheng1
+炢 zhu2
+炣 ke3
+炤 zhao4 zhao1
+炥 fu2
+炦 ba2
+炧 duo4 xie4
+炨 xie4
+炩 ling4
+炪 zhuo2
+炫 xuan4
+炬 ju4
+炭 tan4
+炮 pao4 bao1 pao2
+炯 jiong3
+炰 pao2 pao4
+炱 tai2
+炲 tai2
+炳 bing3
+炴 yang3
+炵 tong1
+炶 han1
+炷 zhu4
+炸 zha4 zha2
+点 dian3
+為 wei4 wei2
+炻 shi2
+炼 lian4
+炽 chi4
+炾 huang3
+烀 hu1
+烁 shuo4 luo4
+烂 lan4
+烃 jing3 ting1
+烄 jiao3
+烅 xu4
+烆 xing2
+烇 quan4 quan3
+烈 lie4
+烉 huan4
+烊 yang2 yang4
+烋 xiao1 xiu1
+烌 xiu1
+烍 xian3
+烎 yin2
+烏 wu1 wu4
+烐 zhou1
+烑 yao2
+烒 shi4
+烓 wei1
+烔 tong2
+烕 xue4 mie4
+烖 zai1
+烗 kai4
+烘 hong1
+烙 luo4 lao4 ge2
+烚 xia2
+烛 zhu2
+烜 xuan3 hui3 xuan1
+烝 zheng1
+烞 po4
+烟 yan1 yin1
+烠 hui3
+烡 guang1
+烢 zhe4
+烣 hui1
+烤 kao3
+烦 fan2
+烧 shao1
+烨 ye4
+烩 hui4
+烫 tang4
+烬 jin4
+热 re4
+烯 xi1
+烰 fu2
+烱 jiong3
+烲 che4
+烳 pu3
+烴 jing3 ting1
+烵 zhuo2
+烶 ting3
+烷 wan2
+烸 hai3
+烹 peng1
+烺 lang3
+烻 shan1 shan2 yan4
+烼 hu1
+烽 feng1
+烾 chi4
+烿 rong2
+焀 hu2
+焂 shu2
+焃 he4
+焄 xun1 hun1
+焅 ku4
+焆 jue2
+焇 xiao1
+焈 xi1 yi2
+焉 yan1 yi2
+焊 han4
+焋 zhuang4
+焌 jun4
+焍 di4
+焎 xie4
+焏 ji2 qi4
+焐 wu4
+焓 han2
+焔 yan4
+焕 huan4
+焖 men4
+焗 ju2
+焘 tao1 chou2
+焙 bei4
+焚 fen2 fen4
+焛 lin4
+焜 kun1 hun3
+焝 hun4
+焞 tun1
+焟 xi2
+焠 cui4
+無 wu2 mo2
+焢 hong1
+焣 ju4
+焤 fu3
+焥 wo4
+焦 jiao1 qiao2
+焧 cong1
+焨 feng4
+焩 ping1
+焪 qiong1
+焫 ruo4 re4
+焬 xi2
+焭 qiong2
+焮 xin4 xin1
+焯 zhuo2 zhuo1 chuo4 chao1
+焰 yan4
+焱 yan4 biao1 yi4
+焲 yi4
+焳 jue2 jiao1
+焴 yu4
+焵 gang4
+然 ran2
+焷 pi2
+焸 gu3
+焺 sheng1
+焻 chang4
+焼 shao1
+煁 chen2 shen2
+煂 he4
+煃 kui3
+煄 zhong1
+煅 duan4
+煆 xia1 xia4
+煇 hui1 xun1 yun4
+煈 feng4
+煉 lian4 lan4
+煊 xuan1
+煋 xing1
+煌 huang2
+煍 jiao3
+煎 jian1 jian3 jian4
+煏 bi4
+煐 ying1
+煑 zhu3
+煒 wei3 hui1
+煓 tuan1
+煔 tian4 qian2 shan1 shan3
+煕 xi1
+煖 nuan3 xuan1
+煗 nuan3
+煘 chan2
+煙 yan1
+煚 jiong3
+煛 jiong3
+煜 yu4
+煝 mei4 mei2
+煞 sha1 sha4
+煟 wei4
+煠 ye4 zha2
+煡 xin4
+煢 qiong2
+煣 rou3
+煤 mei2
+煥 huan4
+煦 xu3 xu4 xiu1
+照 zhao4
+煨 wei1 yu4
+煩 fan2
+煪 qiu2
+煫 sui4
+煬 yang2 yang4
+煭 lie4
+煮 zhu3
+煰 gao4
+煱 gua1
+煲 bao1 bao4
+煳 hu2
+煴 yun1 yun4 wen3
+煵 xia1
+煸 bian1
+煹 gou4
+煺 tui4
+煻 tang2
+煼 chao3
+煽 shan1 shan4
+煾 en1 yun1
+煿 bo2
+熀 huang3
+熁 xie2
+熂 xi4
+熃 wu4
+熄 xi2 xi1
+熅 yun4 yun2 yun1
+熆 he2
+熇 he4
+熈 xi1
+熉 yun2
+熊 xiong2
+熋 nai2
+熌 shan4
+熎 yao4
+熏 xun1 xun4
+熐 mi4
+熑 lian2
+熒 ying2 xing2 jiong3
+熓 wu3 wen4
+熔 rong2
+熗 qiang4
+熘 liu1 liu4
+熙 xi1 yi2
+熚 bi4
+熛 biao1
+熜 zong3
+熝 lu4
+熞 jian1
+熟 shu2 shou2
+熠 yi4
+熡 lou2
+熢 feng1
+熣 sui1
+熤 yi4
+熥 tong1
+熦 jue2
+熧 zong1
+熨 yun4 yu4 wei4
+熩 hu4
+熪 yi2
+熫 zhi4
+熬 ao2 ao1
+熭 wei4
+熮 liao2
+熯 han4
+熰 ou1
+熱 re4
+熲 jiong3
+熳 man4
+熵 shang1
+熶 cuan4
+熷 zeng1
+熸 jian1
+熹 xi1
+熺 xi1
+熻 xi1
+熼 yi4
+熽 xiao4
+熾 chi4
+熿 huang2
+燀 chan3 dan3
+燁 ye4
+燂 qian2 xun2
+燃 ran2
+燄 yan4
+燅 xian2 qian2 xun2
+燆 qiao2
+燇 zun4
+燈 deng1
+燉 dun4 dun1 tun1 tun2
+燊 shen1
+燋 jiao1 qiao2
+燌 fen2 ben4
+燍 si1
+燎 liao3 liao2 liao4
+燏 yu4
+燐 lin2
+燑 tong2
+燒 shao1 shao4
+燓 fen1
+燔 fan2 fen2
+燕 yan4 yan1
+燖 xun2 qian2
+燗 lan4
+燘 mei3
+燙 tang4 dang4
+燚 yi1
+燛 jing3
+燜 men4
+營 ying2 cuo1
+燠 yu4 ao4
+燡 yi4
+燢 xue2
+燣 lan2
+燤 tai4
+燥 zao4 sao4
+燦 can4
+燧 sui4
+燨 xi1
+燩 que4
+燪 cong1
+燫 lian2
+燬 hui3
+燭 zhu2
+燮 xie4
+燯 ling2
+燰 wei1
+燱 yi4
+燲 xie2
+燳 zhao4
+燴 hui4
+燷 lan2
+燸 ru2
+燹 xian3 bing4
+燺 kao3
+燻 xun1
+燼 jin4
+燽 chou2
+燾 tao1 dao4 chou2
+燿 yao4 shao4 shuo4
+爀 he4
+爁 lan4
+爂 biao1
+爃 rong2
+爄 li4
+爅 mo4
+爆 bao4 bo2
+爇 ruo4 re4
+爈 lv2
+爉 la4 lie4
+爊 ao2 ao1
+爋 xun4 xun1
+爌 kuang4 huang4
+爍 shuo4 luo4 yue4
+爏 li4
+爐 lu2
+爑 jue2
+爒 liao4
+爓 yan4 qian2 xun2
+爔 xi1
+爕 xie4
+爖 long2
+爗 ye4
+爙 rang3
+爚 yue4 shuo4
+爛 lan4
+爜 cong2
+爝 jue2 jiao4
+爞 tong2 chong2
+爟 guan4
+爡 che4
+爢 mi2
+爣 tang3
+爤 lan4
+爥 zhu2
+爧 ling2
+爨 cuan4
+爩 yu4
+爪 zhua3 zhao3
+爬 pa2
+爭 zheng1 zheng4
+爮 pao2
+爯 cheng1
+爰 yuan2
+爱 ai4
+爲 wei4 wei2
+爴 jue2
+爵 jue2
+父 fu4 fu3
+爷 ye2
+爸 ba4
+爹 die1
+爺 ye2
+爻 yao2 xiao4
+爼 zu3
+爽 shuang3 shuang1
+爾 er3
+爿 qiang2 pan2
+牀 chuang2
+牁 ge1
+牂 zang1
+牃 die2
+牄 qiang1
+牅 yong2
+牆 qiang2
+片 pian4 pian1 pan4
+版 ban3
+牉 pan4
+牊 shao2
+牋 jian1
+牌 pai2
+牍 du2
+牎 chuang1 cong1
+牏 tou2 yu2 zhu4
+牐 zha2
+牑 bian1
+牒 die2
+牓 bang3
+牔 bo2
+牕 chuang1 cong1
+牖 you3
+牘 du2
+牙 ya2 ya4
+牚 cheng4 cheng1
+牛 niu2
+牝 pin4
+牞 jiu1
+牟 mou2 mu4 mao4
+牠 tuo2 ta1 tuo1
+牡 mu3
+牢 lao2 lao4 lou2
+牣 ren4
+牤 mang2 mang1
+牥 fang1
+牦 mao2 li2
+牧 mu4
+牨 gang1
+物 wu4
+牪 yan4
+牫 ge1
+牬 bei4
+牭 si4
+牮 jian4
+牯 gu3
+牰 you4 chou1
+牱 ge1
+牲 sheng1
+牳 mu3
+牴 di3
+牵 qian1 qian4
+牶 quan4
+牷 quan2
+牸 zi4
+特 te4
+牺 xi1 suo1
+牻 mang2
+牼 keng1
+牽 qian1 qian4
+牾 wu2 wu3
+牿 gu4
+犀 xi1
+犁 li2
+犂 li2
+犃 pou3
+犄 ji1 yi1
+犅 gang1
+犆 zhi2 te4
+犇 ben1
+犈 quan2
+犉 run2
+犊 du2
+犋 ju4
+犌 jia1
+犍 jian1 qian2 jian3
+犎 feng1
+犏 pian1
+犐 ke1
+犑 ju2
+犒 kao4
+犓 chu2
+犔 xi4
+犕 bei4
+犖 luo4
+犗 jie4
+犘 ma2
+犙 san1
+犚 wei4
+犛 li2 mao2
+犜 dun1
+犝 tong2
+犟 jiang4
+犡 li4
+犢 du2
+犣 lie4
+犤 pi2 bei1
+犥 piao3
+犦 bao4 bo2
+犧 xi1 suo1
+犨 chou1
+犩 wei4 wei2
+犪 kui2
+犫 chou1
+犬 quan3
+犮 ba2
+犯 fan4
+犰 qiu2
+犱 ji3
+犲 cai2 chai2
+犳 chuo2
+犴 an4 han1 an2 jian4
+犵 ge1 qi4 he2 jie2
+状 zhuang4
+犷 guang3
+犸 ma4 ma3
+犹 you2
+犺 kang4
+犻 bo2
+犼 hou3
+犽 ya2
+犾 yin2
+犿 huan1 fan1
+狀 zhuang4
+狁 yun3
+狂 kuang2 jue2
+狃 niu3 nv4
+狄 di2 ti4
+狅 qing1
+狆 zhong4
+狇 mu4
+狈 bei4
+狉 pi1
+狊 ju2
+狋 ni2 yi2 yin2
+狌 sheng1 xing1
+狍 pao2
+狎 xia2
+狏 tuo2
+狐 hu2
+狑 ling2
+狒 fei4
+狓 pi1
+狔 ni3
+狕 ao3
+狖 you4
+狗 gou3
+狘 yue4 xue4
+狙 ju1
+狚 dan4
+狛 po4
+狜 gu3
+狝 xian3 mi2
+狞 ning2
+狟 huan2
+狠 hen3 yin2 yan2 ken3 hang3
+狡 jiao3 xiao4
+狢 he2
+狣 zhao4
+狤 ji2
+狥 xun4 xun2
+狦 shan1
+狧 ta4
+狨 rong2
+狩 shou4
+狪 tong1
+狫 lao3
+独 du2
+狭 xia2
+狮 shi1
+狯 hua2 kuai4
+狰 zheng1
+狱 yu4
+狲 sun1
+狳 yu2
+狴 bi4
+狵 mang2
+狶 xi3 xi1
+狷 juan4
+狸 li2 mai2
+狹 xia2
+狺 yin2
+狻 suan1 xun4 jun4
+狼 lang2 lang4 lang3 hang3
+狽 bei4
+狾 zhi4
+狿 yan2
+猀 sha1
+猁 li4
+猂 han4
+猃 xian3
+猄 jing1
+猅 pai2
+猆 fei1
+猇 yao2 xiao1
+猈 ba4
+猉 qi2
+猊 ni2
+猋 biao1
+猌 yin4
+猍 lai2
+猎 xi2 lie4 que4
+猏 jian1
+猐 qiang1
+猑 kun1
+猒 yan1 ya1 yan4
+猓 guo3 luo3
+猔 zong4
+猕 mi2
+猖 chang1
+猗 yi1 e1 wei1 yi3 ji4
+猘 zhi4
+猙 zheng1
+猚 ya2
+猛 meng3
+猜 cai1
+猝 cu4
+猞 she4 she1
+猡 luo2
+猢 hu2
+猣 zong1
+猤 ji4
+猥 wei3 wei4
+猦 feng1
+猧 wo1
+猨 yuan2
+猩 xing1
+猪 zhu1
+猫 mao1 mao2 miao2
+猬 wei4
+猭 yuan2
+献 xian4
+猯 tuan1
+猰 ya4
+猱 nao2
+猲 xie1 xie2 he4
+猳 jia1
+猴 hou2
+猵 bian1
+猶 you2 yao2
+猷 you2
+猸 mei2
+猹 zha1
+猺 yao2
+猻 sun1
+猼 bo2 po4
+猽 ming2
+猾 hua2
+猿 yuan2
+獀 sou1
+獁 ma4 ma3
+獂 yuan2 huan2
+獃 dai1 ai2
+獄 yu4
+獅 shi1
+獆 hao2
+獈 yi4
+獉 zhen1
+獊 chuang4 cang1
+獋 hao2
+獌 man4
+獍 jing4
+獎 jiang3
+獏 mu2 mo4
+獐 zhang1
+獑 chan2
+獒 ao2
+獓 ao2
+獔 hao2
+獕 cui1
+獖 fen2 ben4
+獗 jue2
+獘 bi4
+獙 bi4
+獚 huang2
+獛 pu2
+獜 lin2
+獝 yu4 xu4
+獞 tong2
+獟 yao4 xiao1
+獠 liao2 lao3
+獡 shuo4 xi1 que4
+獢 xiao1
+獥 xi2
+獦 ge2
+獧 juan4
+獨 du2
+獩 hui4
+獪 kuai4 hua2
+獫 xian3
+獬 xie4 ha3 jie3
+獭 ta4 ta3
+獮 xian3 mi2
+獯 xun1
+獰 ning2
+獱 pin2 bian1 bin1
+獲 huo4
+獳 nou4
+獴 meng2 meng3
+獵 lie4
+獶 nao2
+獷 guang3 jing3
+獸 shou4
+獹 lu2
+獺 ta3 ta4
+獻 xian4 suo1 xi1
+獼 mi2
+獽 rang2
+獾 huan1 quan2
+獿 nao2
+玀 luo2 e3
+玁 xian3
+玂 qi2
+玃 jue2
+玄 xuan2 xuan4
+玅 miao4
+玆 zi1 ci1 xuan2
+率 lv4 shuai4 lve4
+玈 lu2
+玉 yu4
+玊 su4
+王 wang2 wang4 yu4
+玌 qiu2
+玍 ga3
+玎 ding1
+玏 le4
+玐 ba1
+玑 ji1
+玒 hong2
+玓 di4
+玔 chuan4 quan4
+玕 gan1
+玖 jiu3
+玗 yu2
+玘 ji3 qi3
+玙 yu2
+玚 yang2 chang4 dang4
+玛 ma3
+玜 gong1
+玝 wu3
+玞 fu1
+玟 min2 wen2
+玠 jie4
+玡 ya4
+玢 bin1 fen1 fen2
+玣 bian4
+玤 bang4 beng3
+玥 yue4
+玦 jue2
+玧 yun3
+玨 jue2
+玩 wan2 wan4
+玪 jian1
+玫 mei2
+玬 dan3
+玭 pi2 pian2 pin2
+玮 wei3
+环 huan2
+现 xian4
+玱 qiang1
+玲 ling2
+玳 dai4
+玴 yi4
+玵 an2
+玶 ping2
+玷 dian4 dian1
+玸 fu2
+玹 xuan2
+玺 xi3
+玻 bo1
+玼 ci3 ci1
+玽 gou3
+玾 jia3
+玿 shao2
+珀 po4
+珁 ci2
+珂 ke1
+珃 ran3
+珄 sheng1
+珅 shen1
+珆 yi2
+珇 zu3
+珈 jia1
+珉 min2 wen2
+珊 shan1
+珋 liu3
+珌 bi4
+珍 zhen1
+珎 zhen1
+珏 jue2
+珐 fa4
+珑 long2
+珒 jin1
+珓 jiao4
+珔 jian4
+珕 li4
+珖 guang1
+珗 xian1
+珘 zhou1
+珙 gong3
+珚 yan1
+珛 xiu4
+珜 yang2
+珝 xu3
+珞 luo4 li4
+珟 su4
+珠 zhu1
+珡 qin2
+珢 ken4
+珣 xun2 xuan1
+珤 bao3
+珥 er3
+珦 xiang4
+珧 yao2
+珨 xia2
+珩 heng2
+珪 gui1
+珫 chong1
+珬 xu4
+班 ban1
+珮 pei4
+珰 dang1
+珲 hun2 hui1
+珳 wen2
+珴 e2
+珵 cheng2
+珶 di4 ti2
+珷 wu3
+珸 wu2
+珹 cheng2
+珺 jun4
+珻 mei2
+珼 bei4
+珽 ting3
+現 xian4
+珿 chuo4
+琀 han2 han4
+琁 xuan2
+琂 yan2
+球 qiu2
+琄 quan3 juan1 xuan4
+琅 lang2 lang4
+理 li3
+琇 xiu4
+琈 fu2
+琉 liu2
+琊 ye2 ya2
+琋 xi1
+琌 ling2
+琍 li4 li2
+琎 jin4 jin1
+琏 lian2 lian3
+琐 suo3
+琓 wan2
+琔 dian4
+琕 pin2 bing3
+琖 zhan3
+琗 cui4
+琘 min2
+琙 yu4
+琚 ju1
+琛 chen1
+琜 lai2
+琝 wen2
+琞 sheng4 wang4
+琟 wei2
+琠 dian3
+琡 chu4
+琢 zhuo2 zuo2
+琣 pei3
+琤 cheng1
+琥 hu3
+琦 qi2
+琧 e4
+琨 kun1
+琩 chang1
+琪 qi2
+琫 beng3
+琬 wan3
+琭 lu4
+琮 cong2
+琯 guan3
+琰 yan3
+琱 diao1
+琲 bei4
+琳 lin2
+琴 qin2
+琵 pi2
+琶 pa2
+琷 que4
+琸 zhuo2
+琹 qin2
+琺 fa4
+琼 qiong2
+琽 du3
+琾 jie4
+琿 hun2 hui1
+瑀 yu3
+瑁 mao4 mei4
+瑂 mei2
+瑄 xuan1
+瑅 ti2
+瑆 xing1
+瑇 dai4
+瑈 rou2
+瑉 min2
+瑊 zhen1 jian1
+瑋 wei3
+瑌 ruan3
+瑍 huan4
+瑎 jie1
+瑏 chuan1
+瑐 jian3
+瑑 zhuan4
+瑒 yang2 chang4 dang4
+瑓 lian4
+瑔 quan2
+瑕 xia2
+瑖 duan4
+瑗 yuan4 huan2
+瑘 ye2
+瑙 nao3
+瑚 hu2
+瑛 ying1
+瑜 yu2
+瑝 huang2
+瑞 rui4
+瑟 se4
+瑠 liu2
+瑢 rong2
+瑣 suo3
+瑤 yao2
+瑥 wen1
+瑦 wu1
+瑧 jin1
+瑨 jin4
+瑩 ying2 ying3
+瑪 ma3
+瑫 tao1
+瑬 liu2
+瑭 tang2
+瑮 li4
+瑯 lang2
+瑰 gui1
+瑱 tian4 zhen4
+瑲 qiang1
+瑳 cuo3 cuo1
+瑴 jue2
+瑵 zhao3
+瑶 yao2
+瑷 ai4
+瑸 bin1
+瑹 tu2
+瑺 chang2
+瑻 kun1
+瑼 zhuan1
+瑽 cong1
+瑾 jin3 jin4
+瑿 yi1
+璀 cui3
+璁 cong1
+璂 qi2
+璃 li2 li5
+璄 ying3
+璅 suo3
+璆 qiu2
+璇 xuan2
+璈 ao2
+璉 lian2 lian3
+璊 men2 man2
+璋 zhang1
+璌 yin2
+璎 ying1
+璏 zhi4
+璐 lu4
+璑 wu2
+璒 deng1
+璔 zeng1
+璕 xun2
+璖 qu2
+璗 dang4
+璘 lin2
+璙 liao2
+璚 qiong2 jue2
+璛 su4
+璜 huang2
+璝 gui1
+璞 pu2
+璟 jing3
+璠 fan2
+璡 jin4 jin1
+璢 liu2
+璣 ji1
+璥 jing3
+璦 ai4
+璧 bi4
+璨 can4
+璩 qu2
+璪 zao3
+璫 dang1
+璬 jiao3
+璭 gun4
+璮 tan3
+璯 hui4
+環 huan2 huan4
+璱 se4
+璲 sui4
+璳 tian2
+璵 yu2
+璶 jin4
+璷 lu2
+璸 bin1
+璹 shou4 shu2
+璺 wen4
+璻 zui3
+璼 lan2
+璽 xi3
+璾 ji4
+璿 xuan2
+瓀 ruan3
+瓁 huo4
+瓂 gai4
+瓃 lei2
+瓄 du2
+瓅 li4
+瓆 zhi2
+瓇 rou2
+瓈 li2
+瓉 zan4
+瓊 qiong2 xuan2
+瓋 zhe2
+瓌 gui1
+瓍 sui4
+瓎 la4
+瓏 long2
+瓐 lu2
+瓑 li4
+瓒 zan4
+瓓 lan4
+瓔 ying1
+瓕 mi2
+瓖 xiang1
+瓗 xi1
+瓘 guan4
+瓙 dao4
+瓚 zan4
+瓛 huan2
+瓜 gua1
+瓝 bo2
+瓞 die2
+瓟 bao2 bo2
+瓠 hu4 hu2 huo4 gu1
+瓡 zhi2
+瓢 piao2
+瓣 ban4
+瓤 rang2
+瓥 li4
+瓦 wa3 wa4
+瓨 jiang1 hong2
+瓪 fan3
+瓫 pen2
+瓬 fang3
+瓭 dan3
+瓮 weng4
+瓯 ou1
+瓳 hu2
+瓴 ling2
+瓵 yi2
+瓶 ping2
+瓷 ci2
+瓹 juan4
+瓺 chang2
+瓻 chi1
+瓽 dang4
+瓾 meng3
+瓿 pou3 bu4
+甀 zhui4
+甁 ping2
+甂 bian1 pian1
+甃 zhou4
+甄 zhen1 zhen4 juan4
+甆 ci2
+甇 ying1
+甈 qi4
+甉 xian2
+甊 lou3
+甋 di4
+甌 ou1 ou3
+甍 meng2
+甎 zhuan1
+甏 peng4 beng4
+甐 lin2
+甑 zeng4
+甒 wu3
+甓 pi4
+甔 dan1
+甕 weng4
+甖 ying1
+甗 yan3
+甘 gan1
+甙 dai4
+甚 shen2 shi2 shen4
+甛 tian2
+甜 tian2
+甝 han1 han2
+甞 chang2
+生 sheng1
+甠 qing2
+甡 shen1 sheng1
+產 chan3
+産 chan3
+甤 rui2
+甥 sheng1
+甦 su1
+甧 sen1
+用 yong4
+甩 shuai3
+甪 lu4
+甫 fu3 pu4 pu3
+甬 yong3 dong4
+甭 beng2 qi4
+甮 feng4
+甯 ning2 ning4
+田 tian2
+由 you2 yao1
+甲 jia3
+申 shen1
+甴 zha2
+电 dian4
+甶 fu2
+男 nan2
+甸 dian4 sheng4 tian2 ying4
+甹 ping2 ping1
+町 ting3 ting1 ding1 zheng4 tian3
+画 hua4
+甼 ting3
+甽 quan3 zhen4
+甾 zi1 zai1
+甿 meng2
+畀 bi4
+畁 qi2 bi4
+畂 liu4 jiu4 mu3
+畃 xun2
+畄 liu2
+畅 chang4
+畆 mu3
+畇 yun2
+畈 fan4
+畉 fu2
+畊 geng1
+畋 tian2
+界 jie4
+畍 jie4
+畎 quan3
+畏 wei4 wei1 wei3
+畐 fu2
+畑 tian2
+畒 mu3
+畔 pan4
+畕 jiang1
+畖 wa1
+畗 da2 fu2
+畘 nan2
+留 liu2 liu3 liu4
+畚 ben3
+畛 zhen3
+畜 chu4 xu4
+畝 mu3
+畞 mu3
+畟 ce4
+畡 gai1
+畢 bi4
+畣 da2
+畤 zhi4
+略 lve4
+畦 qi2 xi2
+畧 lve4
+畨 pan1 fan1
+番 fan1 pan1 bo1 po2 fan2 pan2 pi2
+畫 hua4
+畬 yu2 she1
+畭 yu2
+畮 mu3
+畯 jun4
+異 yi4
+畱 liu2 liu3
+畲 yu2 she1
+畳 die2
+畴 chou2
+畵 hua4
+當 dang1 dang4
+畷 chuo4 zhuo2
+畸 ji1 qi2
+畹 wan3 yuan4
+畺 jiang1
+畻 sheng2
+畼 chang4
+畽 tuan3
+畾 lei2
+畿 ji1
+疀 cha1
+疁 liu2
+疃 tuan3
+疄 lin2
+疅 jiang1
+疆 jiang1 qiang2 jiang4
+疇 chou2
+疈 bo4 pi4
+疉 die2
+疊 die2
+疋 pi3 pi1 shu1 ya3
+疌 nie4
+疍 dan4
+疎 shu1 shu4
+疏 shu1 shu4
+疐 zhi4 di4
+疑 yi2 ni3 ning2
+疒 chuang2
+疓 nai3
+疔 ding1 ne4
+疕 bi3
+疖 jie2
+疗 liao2
+疘 gang1 gong1
+疙 ge1 yi4
+疚 jiu4
+疛 zhou3
+疜 xia4
+疝 shan4
+疞 xu1
+疟 nue4 yao4
+疠 li4
+疡 yang2
+疢 chen4
+疣 you2 you4
+疤 ba1
+疥 jie4
+疦 jue2
+疧 zhi1
+疨 xia1
+疩 cui4
+疪 bi4
+疫 yi4
+疬 li4
+疭 zong4
+疮 chuang1
+疯 feng1
+疰 zhu4
+疱 pao4
+疲 pi2
+疳 gan1
+疴 ke1 e1 qia4
+疵 ci1 zi1 zhai4 ji4
+疶 xie4
+疷 qi2
+疸 dan3 dan4 da5
+疹 zhen3 chen4
+疺 fa2
+疻 zhi3
+疼 teng2
+疽 ju1 ju3
+疾 ji2
+疿 fei4 fei2
+痀 qu2 gou1 ju1 yu3
+痁 dian4 shan1
+痂 jia1
+痃 xian2
+痄 zha4 cha2 zha3
+病 bing4
+痆 ni4 na4
+症 zheng4 zheng1
+痈 yong1
+痉 jing4
+痊 quan2
+痋 chong2
+痌 tong1
+痍 yi2
+痎 kai1 lie1
+痏 wei3
+痐 hui2
+痑 duo3
+痒 yang3 yang2
+痓 chi4
+痔 zhi4
+痕 hen2 gen4
+痖 ya3
+痗 mei4
+痘 dou4
+痙 jing4
+痚 xiao1
+痛 tong4
+痜 tu1
+痝 mang2
+痞 pi3
+痟 xiao1
+痠 suan1
+痡 pu1
+痢 li4
+痣 zhi4
+痤 cuo2
+痥 duo2
+痦 wu4 pi1
+痧 sha1
+痨 lao2
+痩 shou4
+痪 huan4
+痫 xian2
+痬 yi4
+痭 peng2
+痮 zhang4
+痯 guan3
+痰 tan2
+痱 fei4 fei2 fei3
+痲 ma2
+痳 lin2
+痴 chi1
+痵 ji4
+痶 dian3
+痷 an1
+痸 chi4
+痹 bi4
+痺 bi4 bei1
+痻 min2
+痼 gu4 gu1
+痽 dui1
+痾 e1 ke1
+痿 wei3
+瘀 yu1
+瘁 cui4
+瘂 ya3
+瘃 zhu2 zhu3
+瘄 cu4
+瘅 dan4 dan3 dan1
+瘆 shen4
+瘇 zhong3
+瘈 ji4 chi4 zhi4
+瘉 yu4
+瘊 hou2
+瘋 feng1
+瘌 la4
+瘍 yang2 dang4
+瘎 shen4
+瘏 tu2
+瘐 yu3
+瘑 gua1
+瘒 wen2
+瘓 huan4
+瘔 ku4
+瘕 jia3 xia2 xia1
+瘖 yin1
+瘗 yi4
+瘘 lv2 lou4
+瘙 sao1 sao4
+瘚 jue2
+瘛 chi4
+瘜 xi2
+瘝 guan1
+瘞 yi4
+瘟 wen1 wo4 yun1
+瘠 ji2 zi4
+瘡 chuang1
+瘢 ban1
+瘣 lei3
+瘤 liu2
+瘥 chai4 cuo2
+瘦 shou4
+瘧 nue4 yao4
+瘨 dian1
+瘩 da5 da1 da2
+瘪 bie3 bie1 pie1
+瘫 tan1
+瘬 zhang4
+瘭 biao1
+瘮 shen4
+瘯 cu4
+瘰 luo3
+瘱 yi4
+瘲 zong4
+瘳 chou1 lu4
+瘴 zhang4
+瘵 zhai4 ji4
+瘶 sou4
+瘷 suo3
+瘸 que2
+瘹 diao4
+瘺 lou4
+瘻 lv2 lou4
+瘼 mo4
+瘽 jin4
+瘾 yin3
+瘿 ying3
+癀 huang2
+癁 fu2
+療 liao2 shuo4
+癃 long2
+癄 qiao2
+癅 liu2
+癆 lao2 lao4
+癇 xian2
+癈 fei4
+癉 dan4 dan1 dan3 tan2
+癊 yin4
+癋 he4
+癌 ai2 yan2
+癍 ban1
+癎 xian2
+癏 guan1
+癐 guai4
+癑 nong2
+癒 yu4
+癓 wei2
+癔 yi4
+癕 yong1
+癖 pi3
+癗 lei3
+癘 li4
+癙 shu3
+癚 dan4
+癛 lin3 bing3
+癜 dian4
+癝 lin3 bing3
+癞 lai4 la4
+癟 bie3 pie1 bie1
+癠 ji4 ji2
+癡 chi1
+癢 yang3
+癣 xian3 xuan3
+癤 jie2
+癥 zheng1
+癧 li4
+癨 huo4
+癩 lai4 la4
+癫 dian1
+癬 xuan3 xian3
+癭 ying3
+癮 yin3
+癯 qu2
+癰 yong1
+癱 tan1
+癲 dian1
+癳 luo3
+癴 luan2
+癵 luan2
+癶 bo1
+癸 gui3
+癹 po1 ba2
+発 fa1 fa4
+登 deng1 de2
+發 fa1 fa4 bo1
+白 bai2 bo2
+百 bai3 bo2 mo4
+癿 qie2
+皀 bi1 ji2
+皁 zao4
+皂 zao4
+皃 mao4
+的 de5 di2 di4
+皅 pa1
+皆 jie1
+皇 huang2 wang3
+皈 gui1
+皉 ci3
+皊 ling2
+皋 gao1 gu1 hao2
+皌 mo4
+皍 ji2
+皎 jiao3
+皏 peng3
+皐 gao1
+皑 ai2
+皒 e2
+皓 hao4 hui1
+皔 han4
+皕 bi1
+皖 wan3 huan4
+皗 chou2
+皘 qian4
+皙 xi1
+皚 ai2
+皛 jiong3 jiao3 xiao3
+皜 hao4 gao3
+皝 huang3
+皞 hao4
+皟 ze2
+皠 cui3 cui4
+皡 hao4
+皢 xiao3
+皣 ye4
+皤 po2 pan2
+皥 hao4
+皦 jiao3
+皧 ai4
+皨 xing1
+皩 huang4
+皪 li4
+皫 piao3
+皬 he4 he2
+皭 jiao4
+皮 pi2
+皯 gan3
+皰 pao4
+皱 zhou4
+皲 jun1
+皳 qiu2
+皴 cun1
+皵 que4
+皶 zha1 cu3
+皷 gu3
+皸 jun1
+皹 jun1
+皺 zhou4 zhou1
+皻 zha1
+皼 gu3
+皽 zhan3
+皾 du2
+皿 min3 ming3
+盀 qi3
+盁 ying2
+盂 yu2
+盃 bei1
+盄 zhao1 diao4
+盅 zhong1 chong1
+盆 pen2
+盇 he2
+盈 ying2
+盉 he2
+益 yi4
+盋 bo1
+盌 wan3
+盍 he2 ke3
+盎 ang4
+盏 zhan3
+盐 yan2 yan4
+监 jian1 jian4
+盒 he2 an1
+盓 yu1
+盔 kui1
+盕 fan4
+盖 gai4 ge3 he2
+盗 dao4
+盘 pan2
+盙 fu3
+盚 qiu2
+盛 sheng4 cheng2
+盜 dao4
+盝 lu4
+盞 zhan3
+盟 meng2 ming2 meng4
+盠 li3
+盡 jin4 jin3
+盢 xu4
+監 jian1 jian4 kan4
+盤 pan2 xuan2
+盥 guan4
+盦 an1
+盧 lu2
+盨 shu3 xu3
+盩 zhou1 chou1
+盪 dang4
+盫 an1
+盬 gu3
+盭 li4
+目 mu4
+盯 ding1 cheng2
+盰 gan3
+盱 xu1
+盲 mang2 wang4
+盳 mang2 wang4
+直 zhi2
+盵 qi4
+盶 ruan3
+盷 tian2 xuan2
+相 xiang1 xiang4
+盹 dun3 dun4 zhun1
+盺 xin1
+盻 xi4
+盼 pan4 fen2
+盽 feng1
+盾 dun4 shun3 yun3
+盿 min2
+眀 ming2
+省 sheng3 xian3 xing3
+眂 shi4
+眃 yun2
+眄 mian3
+眅 pan1
+眆 fang3
+眇 miao3 miao4
+眈 dan1 tan2 chen3
+眉 mei2
+眊 mao4
+看 kan4 kan1
+県 xian4
+眍 kou1
+眎 shi4
+眏 yang1
+眐 zheng1
+眑 yao3
+眒 shen4
+眓 huo4
+眔 da4
+眕 zhen3
+眖 kuang4
+眗 ju1
+眘 shen4
+眙 yi2 chi4 deng4
+眚 sheng3
+眛 mei4
+眜 mo4 mie4
+眝 zhu4
+眞 zhen1
+真 zhen1
+眠 mian2 mian3 min3
+眡 shi4
+眢 yuan1
+眣 die2
+眤 ni2
+眥 zi4
+眦 zi4
+眧 chao3
+眨 zha3
+眩 xuan4 huan4 juan4
+眪 bing3
+眫 mi3
+眬 long2
+眭 sui1 gui4 hui1 xie2 wei4
+眮 dong4
+眯 mi3 mi1 mi4 mi2
+眰 die2
+眱 yi2
+眲 er4 ne4
+眳 ming3 ming2
+眴 xuan4 shun4
+眵 chi1
+眶 kuang4
+眷 juan4
+眸 mou2
+眹 zhen4
+眺 tiao4
+眻 yang2
+眼 yan3 wen3
+眽 mo4
+眾 zhong4
+眿 mai4
+着 zhao2 zhe5 zhao1 zhuo2
+睁 zheng1
+睂 mei2
+睃 jun4 suo1
+睄 shao4 qiao2
+睅 han4
+睆 huan3
+睇 di4 ti1 ti2
+睈 cheng3
+睉 cuo1
+睊 juan4
+睋 e2
+睌 wan3
+睍 xian4
+睎 xi1
+睏 kun4
+睐 lai4
+睑 jian3
+睒 shan3
+睓 tian3
+睔 hun3 gun3
+睕 wan3 wan1
+睖 ling2 leng4
+睗 shi4
+睘 qiong2
+睙 lie4
+睚 ya2 yai2
+睛 jing1 jing3
+睜 zheng1
+睝 li2
+睞 lai4
+睟 sui4
+睠 juan4
+睡 shui4
+睢 sui1
+督 du1
+睤 bi4
+睥 bi4 pi4
+睦 mu4
+睧 hun1
+睨 ni4
+睩 lu4
+睪 gao1 yi4 hao4 ze2
+睫 jie2 she4
+睬 cai3
+睭 zhou3
+睮 yu2
+睯 hun1
+睰 ma4
+睱 xia4 jia3
+睲 xing3
+睳 xi1
+睴 gun4
+睶 chun3
+睷 jian1
+睸 mei4
+睹 du3
+睺 hou2
+睻 xuan1
+睼 ti4
+睽 kui2 ji4
+睾 gao1 hao4
+睿 rui4
+瞀 mao4 wu2 mou4
+瞁 xu4
+瞂 fa1 fa2
+瞃 wen1
+瞄 miao2
+瞅 chou3
+瞆 kui4 gui4
+瞇 mi1
+瞈 weng3
+瞉 kou4
+瞊 dang4
+瞋 chen1
+瞌 ke1
+瞍 sou3
+瞎 xia1
+瞏 qiong2
+瞐 mao4
+瞑 ming2 ming3 mian2 mian4 meng2
+瞒 man2 men2 men4
+瞓 shui4
+瞔 ze2
+瞕 zhang4
+瞖 yi4
+瞗 diao1
+瞘 ou1
+瞙 mo4
+瞚 shun4
+瞛 cong1
+瞜 lou1
+瞝 chi1
+瞞 man2 men2 men4
+瞟 piao3 piao4 piao1
+瞠 cheng1 zheng4
+瞡 ji4
+瞢 meng2 meng4 mang2
+瞤 run2
+瞥 pie1 bi4
+瞦 xi1
+瞧 qiao2
+瞨 pu2
+瞩 zhu3
+瞪 deng4
+瞫 shen3
+瞬 shun4
+瞭 liao3 liao4 yao3
+瞮 che4
+瞯 xian2 jian4
+瞰 kan4
+瞱 ye4
+瞲 xu4 xue4
+瞳 tong2
+瞴 mou2
+瞵 lin2 lin4 lian2
+瞶 kui4 gui4
+瞷 xian2 jian4
+瞸 ye4
+瞹 ai4
+瞺 hui4
+瞻 zhan1
+瞼 jian3
+瞽 gu3
+瞾 zhao4
+瞿 qu2 ju4 ji2 qu1
+矀 wei2
+矁 chou3
+矂 sao4
+矃 ning3
+矄 xun1
+矅 yao4
+矆 huo4 xue1
+矇 meng2
+矈 mian2
+矉 bin1 pin2
+矊 mian2
+矋 li4
+矌 kuang4
+矍 jue2
+矎 xuan1
+矏 mian2
+矐 huo4
+矑 lu2
+矒 meng2 mang2 meng4
+矓 long2
+矔 guan4
+矕 man3
+矖 xi3
+矗 chu4
+矘 tang3
+矙 kan4
+矚 zhu3
+矛 mao2
+矜 jin1 guan1 qin2
+矝 lin2
+矞 yu4 jue2 xu4
+矟 shuo4
+矠 ce4
+矡 jue2
+矢 shi3
+矣 yi3 xian2
+矤 shen3
+知 zhi1 zhi4
+矦 hou2
+矧 shen3
+矨 ying3
+矩 ju3
+矪 zhou1
+矫 jiao3 jiao2 jiao1
+矬 cuo2
+短 duan3
+矮 ai3
+矯 jiao3 jiao1
+矰 zeng1
+矱 huo4 yue1
+矲 bai3
+石 shi2 dan4
+矴 ding4
+矵 qi4 diao1
+矶 ji1
+矷 zi3
+矸 gan1 gan4
+矹 wu4
+矺 tuo1
+矻 ku4 ku1 wu4
+矼 qiang1 gang1 kong4
+矽 xi4 xi1
+矾 fan2
+矿 kuang4
+砀 dang4
+码 ma3
+砂 sha1
+砃 dan1
+砄 jue2
+砅 li4
+砆 fu1
+砇 min2
+砈 nuo3
+砉 huo4 hua1 xu1
+砊 kang4 kang1
+砋 zhi3
+砌 qi4 qie4
+砍 kan3
+砎 jie4
+砏 fen1 pan1
+砐 e4
+砑 ya4
+砒 pi1
+砓 zhe2
+研 yan2 yan4 xing2
+砕 sui4
+砖 zhuan1 tuan2 tuo2
+砗 che1
+砘 dun4
+砙 pan1
+砚 yan4
+砜 feng1
+砝 fa2 fa3 jie2 ge2
+砞 mo4
+砟 zha4 zuo2 zha3 zuo4
+砠 qu1 ju1
+砡 yu4
+砢 luo3 ke1
+砣 tuo2
+砤 tuo2
+砥 di3 zhi3
+砦 zhai4
+砧 zhen1
+砨 ai4
+砩 fei4 fu2
+砪 mu3
+砫 zhu3 zhu4
+砬 li4 la2
+砭 bian1
+砮 nu3
+砯 ping1
+砰 peng1 ping1 peng4
+砱 ling2
+砲 pao4
+砳 le4
+破 po4
+砵 bo1
+砶 po4
+砷 shen1
+砸 za2
+砹 nuo3 ai4
+砺 li4
+砻 long2
+砼 tong2
+砾 li4
+础 chu3
+硁 keng1
+硂 quan2
+硃 zhu1
+硄 kuang1
+硅 gui1 huo4 he4
+硆 e4
+硇 nao2
+硈 jia2
+硉 lu4
+硊 wei3
+硋 ai4
+硌 luo4 li4 ge4
+硍 ken4
+硎 xing2 yan2 keng1
+硏 yan2
+硐 tong2 dong3 dong4
+硑 peng1
+硒 xi1
+硔 hong2
+硕 shuo4 shi2
+硖 xia2
+硗 qiao1
+硙 wei4 ai2 wei2
+硚 qiao2
+硜 keng1
+硝 xiao1 qiao4
+硞 que4
+硟 chan4
+硠 lang3 lang2
+硡 hong2 hong1
+硢 yu2
+硣 xiao1
+硤 xia2
+硥 mang3
+硦 long4
+硧 yong3 tong2
+硨 che1
+硩 che4
+硪 e2 wo4 yi3
+硫 liu2 chu4
+硬 ying4 geng3
+硭 mang2
+确 que4
+硯 yan4
+硰 sha1
+硱 kun3
+硲 yu4
+硵 lu3
+硶 chen3 cen2
+硷 jian3
+硸 nue4
+硹 song1
+硺 zhuo2
+硻 keng1
+硼 peng2 peng1
+硽 yan3
+硾 zhui4
+硿 kong1
+碀 ceng2
+碁 qi2
+碂 zong4
+碃 qing4
+碄 lin2
+碅 jun1
+碆 bo1
+碇 ding4
+碈 min2
+碉 diao1
+碊 jian1
+碋 he4
+碌 lu4 liu4 luo4
+碍 ai4
+碎 sui4
+碏 que4
+碐 ling2 leng2
+碑 bei1
+碒 yin2
+碓 dui4 dui1
+碔 wu3
+碕 qi2
+碖 lun4
+碗 wan3
+碘 dian3
+碙 gang1
+碚 bei4 pei2
+碛 qi4
+碜 chen3
+碝 ruan3
+碞 yan2
+碟 die2 she2
+碠 ding4
+碡 du2 zhou2
+碢 tuo2
+碣 jie2 ke4 ya4
+碤 ying1
+碥 bian3
+碦 ke4
+碧 bi4
+碨 wei1 wei3
+碩 shuo4 shi2
+碪 zhen1
+碫 duan4
+碬 xia2
+碭 dang4
+碮 ti2
+碯 nao3
+碰 peng4
+碱 jian3 xian2
+碲 di4
+碳 tan4
+碴 cha2 zha1 zha3 cha1
+碶 qi4
+碸 feng1
+碹 xuan4
+確 que4
+碻 que4 qiao1
+碼 ma3
+碽 gong1
+碾 nian3 nian4 lian3
+碿 su4
+磀 e2
+磁 ci2
+磂 liu4
+磃 si1
+磄 tang2
+磅 bang4 pang4 pang2 pang1
+磆 hua2
+磇 pi1
+磈 wei3 kui3
+磉 sang3
+磊 lei3
+磋 cuo1
+磌 zhen1 tian2
+磍 xia2
+磎 qi1 xi1
+磏 lian2
+磐 pan2
+磑 wei4 ai2 wei2
+磒 yun3
+磓 dui1
+磔 zhe2
+磕 ke1 ke3
+磖 la1 la2
+磘 qing4
+磙 gun3
+磚 zhuan1 tuan2 tuo2
+磛 chan2
+磜 qi4
+磝 ao2
+磞 peng1
+磟 lu4 liu4
+磠 lu3
+磡 kan4
+磢 qiang3 chuang3
+磣 chen3 ca4
+磤 yin3 yin1
+磥 lei3
+磦 biao1
+磧 qi4
+磨 mo2 mo4
+磩 qi1 qi4
+磪 cui1
+磫 zong1
+磬 qing4 qing3
+磭 chuo4
+磯 ji1
+磰 shan4
+磱 lao2
+磲 qu2
+磳 zeng1
+磴 deng4 deng1
+磵 jian4
+磶 xi4
+磷 lin2 lin4 lin3 ling2
+磸 ding4
+磹 dian4
+磺 huang2 kuang4
+磻 pan2 bo1
+磼 za2
+磽 qiao1 qiao3 qiao4 ao2
+磾 di1
+磿 li4
+礁 jiao1
+礃 zhang3
+礄 qiao2
+礅 dun1
+礆 xian3 jian3
+礇 yu4
+礈 zhui4
+礉 he2
+礊 huo4
+礋 zhai2 ze2
+礌 lei4 lei2 lei3
+礍 ke3
+礎 chu3
+礏 ji2
+礐 que4
+礑 dang4
+礒 yi3
+礓 jiang1
+礔 pi4
+礕 pi1
+礖 yu4
+礗 pin1
+礘 qi4
+礙 ai4
+礚 kai4 ke1
+礛 jian1 lan2
+礜 yu4
+礝 ruan3
+礞 meng2
+礟 pao4
+礠 ci2
+礡 bo2
+礣 mie4
+礤 ca3
+礥 xian2
+礦 kuang4
+礧 lei4 lei2 lei3
+礨 lei3
+礩 zhi4
+礪 li4
+礫 li4 luo4
+礬 fan2
+礭 que4
+礮 pao4
+礯 ying1
+礰 li4
+礱 long2
+礲 long2
+礳 mo4
+礴 bo2
+礵 shuang1
+礶 guan4
+礷 lan2
+礸 zan3
+礹 yan2
+示 shi4 qi1 zhi4 shi2
+礻 shi4
+礼 li3
+礽 reng2
+社 she4
+礿 yue4
+祀 si4
+祁 qi2 zhi3
+祂 ta1
+祃 ma4
+祄 xie4
+祅 yao1 xian1
+祆 xian1 yao1
+祇 zhi3 qi2 chi2 zhi1
+祈 qi2 gui3
+祉 zhi3
+祊 beng1
+祋 dui4
+祌 zhong4 zhong3
+祎 yi1
+祏 shi2
+祐 you4
+祑 zhi4
+祒 tiao2
+祓 fu2 fei4
+祔 fu4
+祕 mi4
+祖 zu3 jie1
+祗 zhi1
+祘 suan4
+祙 mei4
+祚 zuo4
+祛 qu1
+祜 hu4
+祝 zhu4 zhou4 chu4
+神 shen2 shen1
+祟 sui4
+祠 ci2 si4
+祡 chai2
+祢 ni3 mi2
+祣 lv3
+祤 yu3 xu3
+祥 xiang2
+祦 wu2
+祧 tiao1
+票 piao4 piao1
+祩 zhu1
+祪 gui3
+祫 xia2
+祬 zhi1
+祭 ji4 zhai4
+祮 gao4
+祯 zhen1 zheng1
+祰 gao4
+祱 shui4
+祲 jin1 jin4
+祳 chen3
+祴 gai1
+祵 kun3 hun2
+祶 di4
+祷 dao3
+祸 huo4
+祹 tao2
+祺 qi2
+祻 gu4
+祼 guan4
+祽 zui4
+祾 ling2
+祿 lu4
+禀 bing3 bin3 lin3
+禁 jin4 jin1
+禂 dao3
+禃 zhi2
+禄 lu4
+禅 shan4 chan2
+禆 bi4
+禇 chu3 zhe3 zhu3
+禈 hui1
+禉 you3 chao3
+禊 xi4
+禋 yin1
+禌 zi1
+禍 huo4
+禎 zhen1 zheng1
+福 fu2 fu4
+禐 yuan4
+禑 wu2
+禒 xian3
+禓 yang2
+禔 ti2 zhi1
+禕 yi1
+禖 mei2
+禗 si1
+禘 di4
+禚 zhuo2
+禛 zhen1
+禜 yong3 ying2
+禝 ji2
+禞 gao4
+禟 tang2
+禠 si1
+禡 ma4
+禢 ta1
+禤 xuan1
+禥 qi2
+禦 yu4
+禧 xi3 xi1
+禨 ji1 ji4
+禩 si4
+禪 chan2 shan4 tan2
+禫 tan3 dan4
+禬 kuai4 gui4 hui4
+禭 sui4
+禮 li3
+禯 nong2
+禰 ni3 mi2 xian3
+禱 dao3
+禲 li4
+禳 rang2
+禴 yue4
+禵 ti2
+禶 zan3
+禷 lei4
+禸 rou2
+禹 yu3
+禺 yu2 ou3 yu4
+离 li2 chi1 li4
+禼 xie4
+禽 qin2
+禾 he2
+禿 tu1
+秀 xiu4
+私 si1
+秂 ren2
+秃 tu1
+秄 zi3
+秅 cha2
+秆 gan3
+秇 yi4 zhi2
+秈 xian1
+秉 bing3
+秊 nian2
+秋 qiu1
+秌 qiu1
+种 zhong3 chong2 zhong4
+秎 fen2
+秏 hao4
+秐 yun2
+科 ke1 ke4
+秒 miao3
+秓 zhi1
+秔 geng1 jing1
+秕 bi3
+秖 zhi1 zhi3
+秗 yu4
+秘 mi4 bi4 bie2
+秙 ku4
+秚 ban4
+秛 pi1
+秜 ni2 li2
+秝 li4
+秞 you2
+租 zu1 ju1
+秠 pi1
+秡 ba2
+秢 ling2
+秣 mo4
+秤 cheng4 cheng1 chen4 ping2
+秥 nian2
+秦 qin2
+秧 yang1
+秨 zuo2
+秩 zhi4
+秪 zhi1
+秫 shu2 shu4
+秬 ju4
+秭 zi3
+秮 huo2 kuo4
+积 ji1
+称 cheng1 chen4 cheng4
+秱 tong2
+秲 zhi4
+秳 huo2
+秴 he2
+秵 yin1
+秶 zi1 ci2 ji4
+秷 zhi2
+秸 jie1 ji2
+秹 ren3
+秺 du4
+移 yi2 chi3 yi4
+秼 zhu1
+秽 hui4
+秾 nong2
+秿 fu3
+稀 xi1
+稁 kao3 kao4 gao4
+稂 lang2
+稃 fu1 fu2
+稄 ze4
+稅 shui4 tuan4 tui4 tuo1
+稆 lv3
+稇 kun3
+稈 gan3
+稉 geng1 jing1
+稊 ti2
+程 cheng2
+稌 tu2
+稍 shao1 shao4
+税 shui4 tuan4 tui4 tuo1
+稏 ya4
+稐 lun3
+稑 lu4
+稒 gu4
+稓 zuo2
+稔 ren3
+稕 zhun4
+稖 bang4
+稗 bai4
+稘 ji1
+稙 zhi2
+稚 zhi4
+稛 kun3
+稜 leng2 leng4 ling2
+稝 peng2
+稞 ke1 hua4
+稟 bing3 lin3
+稠 chou2 tiao2 tiao4 diao4
+稡 zu2
+稢 yu4
+稣 su1
+稤 lve4 lve3
+稦 yi1
+稧 xi4
+稨 bian1
+稩 ji4
+稪 fu4
+稫 bi1
+稬 nuo4
+稭 jie1
+種 zhong3 zhong4 chong2
+稯 zong1
+稰 xu1
+稱 cheng1 cheng4 chen4
+稲 dao4
+稳 wen3
+稴 lian2
+稵 zi1 jiu1
+稶 yu4
+稷 ji4 ze4
+稸 xu4
+稹 zhen3 zhen1 bian1
+稺 zhi4
+稻 dao4
+稼 jia4
+稽 ji1 qi3
+稾 gao3
+稿 gao3
+穀 gu3 gou4 nou4
+穁 rong2
+穂 sui4
+穄 ji4
+穅 kang1
+穆 mu4
+穇 shan1 can3
+穈 men2 mei2
+穉 zhi4
+穊 ji4
+穋 lu4
+穌 su1
+積 ji1
+穎 ying3
+穏 wen3
+穐 qiu1
+穑 se4
+穓 yi4
+穔 huang2
+穕 qie4
+穖 ji3
+穗 sui4
+穘 xiao1
+穙 pu2
+穚 jiao1
+穛 zhuo1
+穜 tong2 zhong4
+穞 lv3
+穟 sui4
+穠 nong2
+穡 se4
+穢 hui4
+穣 rang2
+穤 nuo4
+穥 yu4
+穧 ji4
+穨 tui2
+穩 wen3
+穪 cheng1
+穫 huo4
+穬 gong3 kuang4
+穭 lv3
+穮 biao1
+穰 rang2 rang3 reng2
+穱 zhuo1
+穲 li2
+穳 zan4
+穴 xue2 jue2 xue4
+穵 wa1
+究 jiu1 jiu4
+穷 qiong2
+穸 xi4 xi1
+穹 qiong2 qiong1 kong1
+空 kong1 kong4 kong3
+穻 yu1
+穼 sen1
+穽 jing3
+穾 yao4
+穿 chuan1
+窀 zhun1 tun2
+突 tu1 tu2
+窂 lao2
+窃 qie4
+窄 zhai3 ze2
+窅 yao3
+窆 bian3
+窇 bao2
+窈 yao3 yao4
+窉 bing3
+窊 wa1
+窋 zhu2 ku1
+窌 jiao4
+窍 qiao4
+窎 diao4
+窏 wu1
+窐 gui1 wa1
+窑 yao2
+窒 zhi4 die2
+窓 chuang1 cong1
+窔 yao3 yao4
+窕 tiao3 tiao1 yao2
+窖 jiao4 zao4
+窗 chuang1 cong1
+窘 jiong3
+窙 xiao1
+窚 cheng2
+窛 kou4
+窜 cuan4
+窝 wo1
+窞 dan4
+窟 ku1
+窠 ke1
+窡 zhui4
+窢 xu4
+窣 su4 su1
+窥 kui1 kui3
+窦 dou4
+窨 yin4 xun1 yin1
+窩 wo1
+窪 wa1
+窫 ya4
+窬 yu2 dou4 dou1
+窭 ju4 lou2
+窮 qiong2
+窯 yao2
+窰 yao2
+窱 tiao4 tiao3
+窲 chao2
+窳 yu3 yu2
+窴 tian2
+窵 diao4
+窶 ju4 lou2
+窷 liao2
+窸 xi1
+窹 wu4
+窺 kui1 kui3
+窻 chuang1
+窼 zhao1 cong1
+窾 kuan3
+窿 long2
+竀 cheng1
+竁 cui4
+竂 piao2
+竃 zao4
+竄 cuan4 cuan1
+竅 qiao4
+竆 qiong2
+竇 dou4 du2
+竈 zao4
+竉 long3
+竊 qie4
+立 li4 wei4
+竌 chu4
+竎 fou4
+竐 chu4 qi4
+竑 hong2
+竒 qi2
+竖 shu4
+竗 miao4 miao3
+竘 ju3 qu3
+站 zhan4 zhan1
+竚 zhu4
+竛 ling2
+竜 long2
+竝 bing4 bang4
+竞 jing4
+竟 jing4
+章 zhang1 zhang4
+竢 si4
+竣 jun4
+竤 hong2
+童 tong2 zhong1
+竦 song3
+竧 jing4
+竨 diao4
+竩 yi4
+竪 shu4
+竫 jing4
+竬 qu3
+竭 jie2
+竮 ping2
+端 duan1
+竰 shao2
+竱 zhuan3
+竲 ceng2
+竳 deng1
+竴 cui1
+竵 huai1
+競 jing4
+竷 kan4
+竸 jing4
+竹 zhu2
+竺 zhu2 du3
+竻 le4
+竼 peng2
+竽 yu2
+竾 chi2
+竿 gan1 gan4 gan3
+笀 mang2
+笁 zhu2
+笃 du3
+笄 ji1
+笅 xiao2
+笆 ba1
+笇 suan4
+笈 ji2
+笉 zhen3
+笊 zhao4
+笋 sun3
+笌 ya2
+笍 zhui4
+笎 yuan2
+笏 hu4 wen3 wu4
+笐 gang1 hang4
+笑 xiao4
+笒 cen2
+笓 pi2
+笔 bi3
+笕 jian3
+笖 yi3
+笗 dong1
+笘 shan1
+笙 sheng1
+笚 xia2
+笛 di2
+笜 zhu2
+笝 na4
+笞 chi1
+笟 gu1
+笠 li4
+笡 qie4
+笢 min3
+笣 bao1
+笤 tiao2 shao4
+笥 si4
+符 fu2
+笧 ce4
+笨 ben4
+笩 pei4
+笪 da2
+笫 zi3
+第 di4
+笭 ling2
+笮 ze2 zuo2 zha4
+笯 nu2
+笰 fu2
+笱 gou3
+笲 fan2 fan1
+笳 jia1
+笴 ge3 gao3
+笵 fan4
+笶 shi3
+笷 mao3
+笸 po3
+笺 jian1
+笻 qiong2
+笼 long2 long3
+笾 bian1
+笿 luo4
+筀 gui4
+筁 qu3
+筂 chi2
+筃 yin1
+筄 yao4
+筅 xian3
+筆 bi3
+筇 qiong2
+筈 gua1 kuo4
+等 deng3
+筊 jiao3
+筋 jin1 qian2
+筌 quan2
+筍 sun3
+筎 ru2
+筏 fa2
+筐 kuang1
+筑 zhu2 zhu4
+筒 tong3 tong2 dong4
+筓 ji1
+答 da2 da1
+筕 xing2 hang2
+策 ce4
+筗 zhong4
+筘 kou4
+筙 lai2
+筚 bi4
+筛 shai1
+筜 dang1
+筝 zheng1
+筞 ce4
+筟 fu1
+筠 yun2 jun1
+筡 tu2
+筢 pa2
+筣 li4
+筤 lang2
+筥 ju3
+筦 guan3
+筧 jian3 jian4
+筨 han2
+筩 tong3 yong3 dong4 tong2
+筪 xia2
+筫 zhi4
+筬 cheng2
+筭 suan4
+筮 shi4
+筯 zhu4
+筰 zuo2
+筱 xiao3
+筲 shao1
+筳 ting2
+筴 ce4 jia1
+筵 yan2
+筶 gao3
+筷 kuai4
+筸 gan1
+筹 chou2
+筻 gang4
+筼 yun2
+签 qian1
+筿 xiao3
+简 jian3
+箁 pu2
+箂 lai2
+箃 zou1
+箄 bi4 bei1 pai2
+箅 bi4
+箆 bi4
+箇 ge4 ge3
+箈 chi2 dai4 tai2
+箉 guai3
+箊 yu1
+箋 jian1
+箌 zhao4
+箍 gu1
+箎 chi2
+箏 zheng1
+箐 jing1 qing4 qiang1
+箑 sha4 jie2
+箒 zhou3
+箓 lu4
+箔 bo2
+箕 ji1
+箖 lin2
+算 suan4
+箘 jun4
+箙 fu2
+箚 zha2 da2
+箛 gu1
+箜 kong1
+箝 qian2
+箞 quan1
+箟 jun4
+箠 chui2
+管 guan3
+箢 yuan1 wan3
+箣 ce4
+箤 ju2
+箥 bo3
+箦 ze2
+箧 qie4
+箨 tuo4
+箩 luo2
+箪 dan1
+箫 xiao1 xiao3
+箬 ruo4 na4
+箭 jian4
+箯 bian1
+箰 sun3
+箱 xiang1
+箲 xian3
+箳 ping2
+箴 zhen1 jian3
+箵 sheng3 xing1 xing3
+箶 hu2
+箷 shi1
+箸 zhu4 zhuo2
+箹 yue1
+箺 chun3
+箻 lv4
+箼 wu1
+箽 dong3
+箾 shuo4 xiao1 qiao4
+箿 ji2
+節 jie2 jie1
+篁 huang2
+篂 xing1
+篃 mei2
+範 fan4
+篅 chui2 chuan2
+篆 zhuan4
+篇 pian1
+篈 feng1
+築 zhu2 zhu4
+篊 hong2
+篋 qie4
+篌 hou2
+篍 qiu1
+篎 miao3
+篏 qian4
+篑 kui4
+篓 lou3
+篔 yun2
+篕 he2
+篖 tang2
+篗 yue4
+篘 chou1
+篙 gao1
+篚 fei3
+篛 ruo4
+篜 zheng1
+篝 gou1
+篞 nie4
+篟 qian4
+篠 xiao3
+篡 cuan4
+篢 gong1 long3
+篣 pang2 peng2
+篤 du3
+篥 li4
+篦 bi4 pi2
+篧 zhuo2
+篨 chu2
+篩 shai1 shi1
+篪 chi2
+篫 zhu2
+篬 qiang1
+篭 long2
+篮 lan2
+篯 jian1
+篰 bu4
+篱 li2
+篲 hui4 sui4
+篳 bi4
+篴 di2
+篵 cong1
+篶 yan1
+篷 peng2
+篸 sen1 cen1 zan1
+篹 zhuan4 suan3 zuan3 zuan4
+篺 pai2
+篻 piao4 piao3
+篼 dou1
+篽 yu3
+篾 mie4
+篿 zhuan1 tuan2
+簀 ze2 zhai4
+簁 xi3
+簂 guo2
+簃 yi2
+簄 hu4
+簅 chan3
+簆 kou4
+簇 cu4 cou4 chuo4
+簈 ping2
+簉 chou4 zao4
+簊 ji1
+簋 gui3
+簌 su4
+簍 lou3 lv3 ju4
+簎 zha4
+簏 lu4
+簐 nian3
+簑 suo1
+簒 cuan4
+簔 suo1
+簕 le4
+簖 duan4
+簘 xiao1 xiao3
+簙 bo2
+簚 mi4
+簛 si1
+簜 dang4
+簝 liao2 lao3
+簞 dan1
+簟 dian4
+簠 fu3
+簡 jian3
+簢 min3
+簣 kui4
+簤 dai4
+簥 jiao1 qiao2
+簦 deng1
+簧 huang2
+簨 sun3
+簩 lao2
+簪 zan1 zan3
+簫 xiao1 xiao3
+簬 lu4 du4
+簭 shi4
+簮 zan1 zan3
+簰 pai2 bei1
+簲 pai2
+簳 gan4 gan3
+簴 ju4
+簵 du4 lu4
+簶 lu4
+簷 yan2
+簸 bo4 bo3
+簹 dang1
+簺 sai4
+簻 ke1 zhua1
+簼 long2
+簽 qian1
+簾 lian2
+簿 bu4 bo2
+籀 zhou4
+籁 lai4
+籃 lan2
+籄 kui4
+籅 yu2
+籆 yue4
+籇 hao2
+籈 zhen1
+籉 tai2
+籊 ti4 di2
+籋 mi2
+籌 chou2 tao2
+籍 ji2 jie4
+籐 teng2
+籑 zhuan4 xuan3
+籒 zhou4
+籓 fan1 fan2
+籔 sou3 shu4
+籕 zhou4
+籗 zhuo2
+籘 teng2
+籙 lu4
+籚 lu2
+籛 jian1
+籜 tuo4
+籝 ying2
+籞 yu4
+籟 lai4
+籠 long2 long3
+籢 lian2
+籣 lan2
+籤 qian1
+籥 yue4
+籦 zhong1
+籧 qu2 ju3
+籨 lian2
+籩 bian1
+籪 duan4
+籫 zuan3
+籬 li2
+籭 si1
+籮 luo2
+籯 ying2
+籰 yue4
+籱 zhuo2
+籲 yu4 xu1
+米 mi3
+籴 di2 za2
+籵 fan2
+籶 shen1
+籷 zhe2
+籸 shen1
+籹 nv3
+籺 xie2 he2
+类 lei4 li4
+籼 xian1
+籽 zi3
+籾 ni2
+籿 cun4
+粁 qian1
+粃 bi3
+粄 ban3
+粅 wu4
+粆 sha1
+粇 kang1
+粈 rou3
+粉 fen3
+粊 bi4
+粋 cui4
+粍 li2
+粎 chi3
+粑 ba1
+粒 li4
+粓 gan1
+粔 ju4
+粕 po4
+粖 mo4
+粗 cu1
+粘 zhan1 nian2 lian1
+粙 zhou4
+粚 li2
+粛 su4
+粜 tiao4
+粝 li4
+粞 xi1 qi1
+粟 su4
+粠 hong2
+粡 tong2
+粢 zi1 ci2 ji4
+粣 ce4 san3
+粤 yue4
+粥 zhou1 yu4 zhu4
+粦 lin4 lin2
+粧 zhuang1
+粨 bai3
+粪 fen4 san1
+粮 liang2
+粯 xian4
+粰 fu2 fu1
+粱 liang2
+粲 can4
+粳 geng1 jing1
+粴 li3
+粵 yue4
+粶 lu4
+粷 ju2
+粸 qi2
+粹 cui4 sui4
+粺 bai4
+粻 zhang1
+粼 lin2 lin3
+粽 zong4
+精 jing1 qing2 jing4
+粿 guo3
+糁 san1 san3
+糂 san3
+糃 tang2
+糄 bian1
+糅 rou3 rou2
+糆 mian4
+糇 hou2
+糈 xu3
+糉 zong4
+糊 hu2 hu1 hu4
+糋 jian4
+糌 zan2 zan1
+糍 ci2 zi1
+糎 li2
+糏 xie4
+糐 fu1
+糑 ni4
+糒 bei4
+糓 gu3
+糔 xiu3 xiu1
+糕 gao1
+糖 tang2
+糗 qiu3
+糙 cao1
+糚 zhuang1
+糛 tang2
+糜 mi2 mei2
+糝 san3 san1
+糞 fen4
+糟 zao1
+糠 kang1
+糡 jiang4
+糢 mo2
+糣 san3 san1
+糤 san3
+糥 nuo4
+糦 xi1 chi4
+糧 liang2
+糨 jiang4 jiang1
+糩 kuai4
+糪 bo2
+糫 huan2
+糭 zong4
+糮 xian4
+糯 nuo4
+糰 tuan2
+糱 nie4
+糲 li4
+糳 zuo4
+糴 di2
+糵 nie4
+糶 tiao4
+糷 lan2
+糸 mi4 si1
+糹 si1
+糺 jiu1 jiu3 jiao3
+系 xi4 ji4
+糼 gong1
+糽 zheng3
+糾 jiu1 jiu3
+糿 you4
+紀 ji4 ji3
+紁 cha4
+紂 zhou4
+紃 xun2
+約 yue1 yao1 yao4 di4
+紅 hong2 gong1 jiang4
+紆 yu1 yu3 ou1
+紇 he2 ge1 jie2
+紈 wan2
+紉 ren4
+紊 wen4 wen3
+紋 wen2 wen4
+紌 qiu2
+納 na4
+紎 zi1
+紏 tou3
+紐 niu3
+紑 fou2
+紒 jie4 ji4
+紓 shu1
+純 chun2 quan2 tun2 zhun1 zhun3 zi1
+紕 pi1 pi2 bi3 bi1 bi4 chi3
+紖 yin3 zhen4
+紗 sha1 miao3
+紘 hong2
+紙 zhi3
+級 ji2
+紛 fen1
+紜 yun2
+紝 ren4 ren2
+紞 dan3
+紟 jin1 jin4
+素 su4
+紡 fang3 bang3 fang4
+索 suo3
+紣 cui4 zu2
+紤 jiu3
+紥 zha2 za1
+紧 jin3
+紨 fu4
+紩 zhi4
+紪 ci3
+紫 zi3
+紬 chou2 chou1
+紭 hong2
+紮 za1 zha1 zha2
+累 lei4 lei3 lei2 lv4 lie4
+細 xi4
+紱 fu2
+紲 xie4 yi4
+紳 shen1
+紴 bei4
+紵 zhu4
+紶 qu3
+紷 ling2
+紸 zhu4
+紹 shao4 chao1
+紺 gan4
+紻 yang1
+紼 fu2 fei4
+紽 tuo2
+紾 zhen3 tian3
+紿 dai4
+絀 chu4 zhuo2
+絁 shi1
+終 zhong1
+絃 xian2
+組 zu3 qu1
+絅 jiong3
+絆 ban4
+絇 ju4 qu2
+絈 mo4
+絉 shu4
+絊 zui4
+経 jing1
+絍 ren2 ren4
+絎 heng4 hang2
+絏 xie4 yi4
+結 jie2 ji4 jie1
+絑 zhu1
+絒 chou2
+絓 gua4
+絔 bai3
+絕 jue2
+絖 kuang4
+絗 hu2
+絘 ci4
+絙 geng1
+絚 geng1 geng4
+絛 tao1
+絜 xie2 jie2
+絝 ku4
+絞 jiao3 xiao2 jiao4
+絟 quan1
+絠 gai3
+絡 luo4 lao4
+絢 xuan4 xun2
+絣 bing1 beng1
+絤 xian4
+絥 fu2 bei4
+給 gei3 ji3 xia2
+絧 tong2
+絨 rong2
+絩 tiao4
+絪 yin1
+絫 lei3
+絬 xie4
+絭 quan4 juan4
+絮 xu4 nv4 qu4 chu4 na4
+絯 gai1
+絰 die2
+統 tong3
+絲 si1
+絳 jiang4
+絴 xiang2
+絵 hui4
+絶 jue2
+絷 zhi2
+絸 jian3
+絹 juan4 xuan4
+絺 chi1
+絻 mian3 wen4
+絼 zhen3 zhi4
+絽 lv3
+絾 cheng2
+絿 qiu2
+綀 shu1
+綁 bang3
+綂 tong3
+綃 xiao1 shao1
+綄 wan4 huan3
+綅 qin1 xian1
+綆 geng3 bing3
+綇 xiu3
+綈 ti2 ti4
+綉 xiu4 tou4
+綊 xie2
+綋 hong2
+綌 xi4
+綍 fu2
+綎 ting1 ting2
+綏 sui1 sui2 shuai1 rui2 tuo3
+綐 dui4
+綑 kun3
+綒 fu1
+經 jing1 jing4
+綔 hu4
+綕 zhi1
+綖 yan2
+綗 jiong3
+綘 feng2
+継 ji4
+綜 zong1 zong4 zeng4
+綝 lin2 chen1 shen1
+綞 duo3
+綟 li4
+綠 lv4 lu4
+綡 liang2
+綢 chou2 tao1 diao4
+綣 quan3
+綤 shao4
+綥 qi4
+綦 qi2
+綧 zhun3
+綨 qi2
+綩 wan3
+綪 qian4 zheng1
+綫 xian4
+綬 shou4
+維 wei2 yi2
+綮 qi3 qing4
+綯 tao2 ku4
+綰 wan3
+綱 gang1
+網 wang3
+綳 beng1 beng3
+綴 zhui4 chuo4
+綵 cai3
+綶 guo3
+綷 cui4
+綸 lun2 guan1
+綹 liu3
+綺 qi3 yi3
+綻 zhan4
+綼 bei1 bi4
+綽 chuo4 chao1
+綾 ling2
+綿 mian2
+緀 qi1
+緁 qie4 ji1 qi1 qi4
+緂 tan1 tian2
+緃 zong1
+緄 gun3 hun4 hun2
+緅 zou1
+緆 yi4 xi4
+緇 zi1
+緈 xing4
+緉 liang3
+緊 jin3
+緋 fei1
+緌 rui2
+緍 min2
+緎 yu4
+総 zong3
+緐 fan2 pan2 po2
+緑 lv4
+緒 xu4
+緓 ying1
+緔 zhang4
+緖 xu4
+緗 xiang1
+緘 jian1
+緙 ke4
+線 xian4
+緛 ruan3
+緜 mian2
+緝 ji1 qi4 qi1 ji2
+緞 duan4
+緟 zhong4
+締 di4
+緡 min2 min3 mian2 hun2
+緢 miao2
+緣 yuan2 yuan4
+緤 xie4
+緥 bao3
+緦 si1
+緧 qiu1
+編 bian1 bian4 bian3
+緩 huan3
+緪 geng1 geng4
+緫 cong1 zong1 zong3
+緬 mian3
+緭 wei4
+緮 fu4
+緯 wei3
+緰 yu2
+緱 gou1
+緲 miao3
+緳 xie2
+練 lian4
+緵 zong1 zong4
+緶 bian4 pian2 bian3
+緷 yun4
+緸 yin1
+緹 ti2
+緺 gua1 guo1 wo1
+緻 zhi4
+緼 yun1
+緽 cheng1
+緾 chan2
+緿 dai4
+縀 xia2
+縁 yuan2
+縂 zong3 zong1
+縃 xu1
+縆 geng1
+縈 ying2
+縉 jin4
+縊 yi4
+縋 zhui4
+縌 ni4
+縍 bang1
+縎 gu3
+縏 pan2
+縐 zhou4 chao4 cu4 zhou1
+縑 jian1
+縒 cuo3
+縓 quan3 quan4
+縔 shuang3
+縕 yun1 yun4
+縖 xia2
+縗 cui1 sui1 shuai1
+縘 xi1
+縙 rong2
+縚 tao1
+縛 fu2
+縜 yun2
+縝 chen1 zhen3 zhen1
+縞 gao3
+縟 ru4 rong3
+縠 hu2
+縡 zai3 zai4
+縢 teng2
+縣 xian4 xuan2
+縤 su4
+縥 zhen3
+縦 zong4 cong2 zong3
+縧 tao1
+縩 cai4
+縪 bi4
+縫 feng2 feng4
+縬 cu4
+縭 li2
+縮 suo1 su4
+縯 yin3 yan3
+縰 xi3
+縱 zong4 zong3 song3 cong2
+縲 lei2
+縳 zhuan4
+縴 qian1 qian4
+縵 man4
+縶 zhi2
+縷 lv3
+縸 mo4 mu4
+縹 piao3 piao1
+縺 lian2
+縻 mi2
+縼 xuan4
+總 zong3 zong1
+績 ji1
+縿 shan1
+繀 sui4
+繁 fan2 po2 pan2
+繂 shuai4
+繃 beng1 beng3 beng4
+繄 yi1
+繅 sao1 zao3
+繆 mou2 jiu1 liao3 miao4 miu4 mu4
+繇 yao2 you2 zhou4 yao1
+繈 qiang3 jiang3
+繉 hun2
+繋 xi4
+繍 xiu4
+繎 ran2
+繏 xuan4
+繐 sui4 hui4
+繑 qiao1
+繒 zeng1 ceng2 zeng4
+繓 zuo3
+織 zhi1 zhi4
+繕 shan4
+繖 san3
+繗 lin2
+繘 yu4 ju2
+繙 fan1 fan2
+繚 liao2 rao3
+繛 chuo4 chao1
+繜 zun1 zun3
+繝 jian4
+繞 rao4 rao3
+繟 chan3
+繠 rui3
+繡 xiu4
+繢 hui4 hui2
+繣 hua4
+繤 zuan3
+繥 xi1
+繦 qiang3 jiang3
+繨 da2 da5
+繩 sheng2 min3 ying4 sheng4
+繪 hui4 gui4
+繫 xi4 ji4
+繬 se4
+繭 jian3
+繮 jiang1
+繯 huan2 huan4
+繰 zao3 qiao1 sao1
+繱 cong1
+繲 jie4
+繳 jiao3 zhuo2 jiao4 he2
+繴 bo4 bi4
+繵 chan2
+繶 yi4
+繷 nao2
+繸 sui4
+繹 yi4 shi4
+繺 shai3
+繻 xu1 ru2
+繼 ji4
+繽 bin1
+繾 qian3
+繿 lan2
+纀 pu2 bu2 fu2
+纁 xun1
+纂 zuan3 zuan4
+纃 qi2
+纄 peng2
+纅 li4
+纆 mo4
+纇 lei4
+纈 xie2
+纉 zuan3
+纊 kuang4
+纋 you1
+續 xu4
+纍 lei2 lei4 lei3
+纎 xian1
+纏 chan2
+纑 lu2
+纒 chan2
+纓 ying1
+纔 cai2
+纕 xiang1 rang2
+纖 xian1 jian1
+纗 zui1
+纘 zuan3
+纙 luo4
+纚 xi3 li2 li3 shai3 shi1 shi3
+纛 dao4 du2
+纜 lan4
+纝 lei2
+纞 lian4
+纟 si1
+纠 jiu1 jiu3 jiao3
+纡 yu1 yu3
+红 hong2 hong1 gong1
+纣 zhou4
+纤 xian1 jian1 qian4
+纥 he2 ge1
+约 yue1
+级 ji2
+纨 wan2
+纩 kuang4
+纪 ji4 ji3
+纫 ren4
+纬 wei3
+纭 yun2
+纮 hong2
+纯 chun2 quan2 tun2 zhun1 zhun3
+纰 pi2 bi3 pi1
+纱 sha1
+纲 gang1
+纳 na4
+纴 ren2 ren4
+纵 zong4 zong3 song3
+纶 lun2 guan1
+纷 fen1
+纸 zhi3
+纹 wen2
+纺 fang3 bang3
+纻 zhu4
+纼 yin3 zhen4
+纽 niu3
+纾 shu1
+线 xian4
+绀 gan4
+绁 xie4 yi4
+绂 fu2
+练 lian4
+组 zu3
+绅 shen1
+细 xi4
+织 zhi1 zhi4
+终 zhong1
+绉 zhou4
+绊 ban4
+绋 fu2
+绌 zhuo2 chu4
+绍 shao4
+绎 yi4
+经 jing1 jing4
+绐 dai4
+绑 bang3
+绒 rong2
+结 jie2 jie1 ji4
+绔 ku4
+绕 rao4 rao3
+绖 die2
+绗 heng4 hang2
+绘 hui4
+给 gei3 ji3
+绚 xuan4
+绛 jiang4
+络 luo4 lao4
+绝 jue2
+绞 jiao3
+统 tong3
+绠 geng3
+绡 xiao1
+绢 juan4
+绣 xiu4
+绤 xi4
+绥 sui1 sui2 tuo3
+绦 tao1
+继 ji4
+绨 ti2 ti4
+绩 ji1
+绪 xu4
+绫 ling2
+绬 ying1
+续 xu4
+绮 qi3
+绯 fei1
+绰 chuo4 chao1
+绱 zhang3
+绲 gun3
+绳 sheng2 min3 ying4
+维 wei2
+绵 mian2
+绶 shou4
+绷 beng1 beng3 beng4
+绸 chou2 tao1
+绹 tao2 ku4
+绺 liu3
+绻 quan3
+综 zong4 zong1 zeng4
+绽 zhan4
+绾 wan3
+绿 lv4 lu4
+缀 zhui4 chuo4
+缁 zi1
+缂 ke4
+缃 xiang1
+缄 jian1
+缅 mian3
+缆 lan4
+缇 ti2
+缈 miao3
+缉 ji1 qi4 qi1
+缊 yun1 yun4 wen1
+缋 hui4
+缌 si1
+缍 duo3
+缎 duan4
+缏 bian4 pian2
+缐 xian4
+缑 gou1
+缒 zhui4
+缓 huan3
+缔 di4
+缕 lv3
+编 bian1 bian4
+缗 min2
+缘 yuan2 yuan4
+缙 jin4
+缚 fu2
+缛 ru4
+缜 zhen1 zhen3
+缝 feng2 feng4
+缞 shuai1 cui1
+缟 gao3
+缠 chan2
+缡 li2
+缢 yi4
+缣 jian1
+缤 bin1
+缥 piao3 piao1
+缦 man4
+缧 lei2
+缨 ying1
+缩 suo1 su4
+缪 mou2 jiu1 liao3 miao4 miu4 mu4
+缫 sao1 zao3
+缬 xie2
+缭 liao2
+缮 shan4
+缯 zeng1 ceng2
+缰 jiang1
+缱 qian3
+缲 zao3 qiao1 sao1
+缳 huan2 huan4
+缴 jiao3 zhuo2
+缵 zuan3
+缶 fou3 guan4
+缷 xie4
+缸 gang1 hong2
+缹 fou3
+缺 que1
+缻 fou3
+缽 bo1
+缾 ping2
+缿 hou4 xiang4
+罁 gang1
+罂 ying1
+罃 ying1
+罄 qing4
+罅 xia4
+罆 guan4
+罇 zun1
+罈 tan2
+罊 qi4
+罋 weng4
+罌 ying1
+罍 lei2
+罎 tan2
+罏 lu2
+罐 guan4
+网 wang3
+罒 wang3
+罓 gang1
+罔 wang3 wang2
+罕 han3 han4
+罗 luo1 luo2 luo5
+罘 fu2 fu1
+罙 mi2 shen1
+罚 fa2
+罛 gu1
+罜 zhu3
+罝 ju1 jie1
+罞 mao2
+罟 gu3
+罠 min2
+罡 gang1
+罢 ba4 ba5 bai3 pi2
+罣 gua4
+罤 ti2
+罥 juan4
+罦 fu2 fu1
+罧 lin2 shen1
+罨 yan3
+罩 zhao4
+罪 zui4
+罫 gua4 guai3 hua4
+罬 zhuo2
+罭 yu4
+置 zhi4
+罯 an3
+罰 fa2
+罱 nan3 lan3
+署 shu3
+罳 si1
+罴 pi2
+罵 ma4
+罶 liu3
+罷 ba4 ba5 bai3 pi2 pi4 bi3
+罸 fa2
+罹 li2
+罺 chao1
+罻 wei4 yu4
+罼 bi4
+罽 ji4
+罾 zeng1
+罿 tong2 chong1
+羀 liu3
+羁 ji1
+羂 juan4
+羃 mi4
+羄 zhao4
+羅 luo2 luo1 luo5
+羆 pi2
+羇 ji1
+羈 ji1
+羉 luan2
+羊 yang2
+羋 mi3 mie1
+羌 qiang1
+羍 ta4 da2
+美 mei3
+羏 yang2
+羐 you3
+羑 you3
+羒 fen2
+羓 ba1
+羔 gao1
+羕 yang4
+羖 gu3
+羗 qiang1
+羘 zang1
+羙 gao1
+羚 ling2
+羛 yi4 xi4
+羜 zhu4
+羝 di1 di3
+羞 xiu1
+羟 qiang1
+羠 yi2
+羡 xian4 yi2 yan2
+羢 rong2
+羣 qun2
+群 qun2
+羥 qiang3 qian1
+羦 huan2
+羧 suo1 zui1
+羨 xian4 yi2 yan2
+義 yi4
+羫 qiang1
+羬 xian2
+羭 yu2
+羮 geng1 lang2
+羯 jie2
+羰 tang1
+羱 yuan2
+羲 xi1
+羳 fan2
+羴 shan1
+羵 fen3
+羶 shan1
+羷 lian3
+羸 lei2 lian2
+羹 geng1 lang2
+羺 nou2
+羻 qiang4
+羼 chan4
+羽 yu3 hu4
+羾 gong4
+羿 yi4
+翀 chong1 chong2
+翁 weng1 weng3
+翂 fen1
+翃 hong2
+翄 chi4
+翅 chi4
+翆 cui4
+翇 fu2
+翈 xia2
+翉 pen3
+翊 yi4
+翋 la1 la4
+翌 yi4
+翍 pi1
+翎 ling2
+翏 liu4 liao4 liu2
+翐 zhi4
+翑 qu2
+習 xi2
+翓 xie2
+翔 xiang2
+翕 xi4
+翖 xi4
+翗 qi2
+翘 qiao2 qiao4
+翙 hui4
+翚 hui1
+翛 xiao1 shu4
+翜 se4 sha4
+翝 hong2
+翞 jiang1
+翟 zhai2 di2
+翠 cui4
+翡 fei3
+翢 tao1
+翣 sha4
+翤 chi4
+翥 zhu4
+翦 jian3
+翧 xuan1
+翨 shi4 chi4
+翩 pian1
+翪 zong1
+翫 wan4 wan1
+翬 hui1
+翭 hou2
+翮 he2 li4
+翯 he4 he2
+翰 han4
+翱 ao2
+翲 piao1
+翳 yi4
+翴 lian2
+翵 qu2
+翷 lin2
+翸 pen3
+翹 qiao2 qiao4
+翺 ao2
+翻 fan1
+翼 yi4
+翽 hui4
+翾 xuan1
+翿 dao4
+耀 yao4
+老 lao3
+考 kao3
+耄 mao4
+者 zhe3 zhu1
+耆 qi2 shi4 zhi3
+耇 gou3
+耈 gou3
+耉 gou3
+耊 die4
+耋 die4
+而 er2 neng2
+耍 shua3
+耎 ruan3
+耏 er2 nai4
+耐 nai4 neng2
+耑 zhuan1 duan1
+耒 lei3
+耓 ting1
+耔 zi3
+耕 geng1
+耖 chao4
+耗 hao4 mao2 mao4
+耘 yun2
+耙 ba4 pa2 ba3
+耚 pi1
+耛 chi2
+耜 si4
+耝 chu2
+耞 jia1
+耟 ju4
+耠 he2 huo1
+耡 chu2
+耢 lao4
+耣 lun3
+耤 ji2 jie4
+耥 tang3
+耦 ou3
+耧 lou2
+耨 nou4
+耩 jiang3 gou1
+耪 pang3
+耫 ze2
+耬 lou2 lou3
+耭 ji1
+耮 lao4
+耯 huo4
+耰 you1
+耱 mo4
+耲 huai2
+耳 er3 reng2
+耴 zhe2
+耵 ting1 ding1 ding3
+耶 ye2 ye1 xie2
+耷 da1 zhe2
+耸 song3
+耹 qin2
+耺 yun2
+耻 chi3
+耼 dan1
+耽 dan1
+耾 hong2
+耿 geng3
+聀 zhi2 zhi4
+聂 nie4 zhe4
+聃 dan1
+聄 zhen3
+聅 che4
+聆 ling2
+聇 zheng1
+聈 you3
+聉 wa1
+聊 liao2 liu2
+聋 long2
+职 zhi2 zhi4
+聍 ning2 ning3
+聎 tiao1
+聏 er2
+聐 ya4
+聑 die2
+聒 guo1 gua1
+联 lian2
+聕 hao4
+聖 sheng4
+聗 lie4
+聘 pin4 ping4
+聙 jing1
+聚 ju4
+聛 bi4
+聜 di3
+聝 guo2
+聞 wen2 wen4
+聟 xu4
+聠 ping2
+聡 cong1
+聤 ting2
+聥 yu3
+聦 cong1
+聧 kui2
+聩 kui4
+聪 cong1
+聫 lian2
+聬 weng3
+聭 kui4
+聮 lian2
+聯 lian2
+聰 cong1
+聱 ao2 you2
+聲 sheng1
+聳 song3
+聴 ting1
+聵 kui4
+聶 nie4 zhe4 she4 zhe2 ye4
+職 zhi2 zhi4 te4
+聸 dan1
+聹 ning2 ning3
+聻 ji1 ji2 jian4
+聼 ting1 ting4
+聽 ting1 ting4
+聾 long2
+聿 yu4
+肀 yu4
+肁 zhao4
+肂 si4
+肃 su4
+肄 yi4 si4
+肅 su4
+肆 si4 ti4
+肇 zhao4
+肈 zhao4
+肉 rou4 ru4
+肊 yi4
+肋 lei4 le4 le1 jin1
+肌 ji1 ji4
+肍 qiu2
+肎 ken3
+肏 cao4
+肐 ge1
+肑 di4
+肒 huan2
+肓 huang1
+肔 yi3
+肕 ren4
+肖 xiao4 xiao1
+肗 ru3
+肘 zhou3
+肙 yuan1
+肚 du4 du3
+肛 gang1
+肜 rong2 chen1
+肝 gan1
+肞 cha1
+肟 wo4
+肠 chang2
+股 gu3
+肢 zhi1 shi4
+肣 han2
+肤 fu1
+肥 fei2 bi3
+肦 fen2 ban1
+肧 pei1
+肨 pang4
+肩 jian1 xian2
+肪 fang2
+肫 zhun1 chun2 tun2 zhuo1
+肬 you2
+肭 na4 nv4
+肮 hang2 gang1 ang1 kang3
+肯 ken3
+肰 ran2
+肱 gong1
+育 yu4 yo1
+肳 wen3
+肴 yao2
+肵 jin4 qi2
+肶 pi2
+肷 qian1 xu4 qian3
+肸 xi4 xi1 bi4
+肹 xi1 bi4
+肺 fei4 pei4
+肻 ken3
+肼 jing3
+肽 tai4
+肾 shen4
+肿 zhong3
+胀 zhang4
+胁 xie2
+胂 shen1 shen4 chen1
+胃 wei4
+胄 zhou4
+胅 die2
+胆 dan3 tan2 tan3 da2
+胇 fei4
+胈 ba2
+胉 bo2
+胊 qu2
+胋 tian2
+背 bei4 bei1
+胍 gua1 gu1 hu4
+胎 tai1
+胏 zi3 fei4
+胐 ku1 pei2
+胑 zhi1 zhi2 zhu1
+胒 ni4
+胓 ping2
+胔 zi4
+胕 fu4 fu2 fu1
+胖 pang4 pan2 pan4
+胗 zhen1 zhen3 zhun1
+胘 xian2
+胙 zuo4
+胚 pei1
+胛 jia3
+胜 sheng4 sheng1
+胝 zhi1 chi1 di4
+胞 bao1 pao2 pao4
+胟 mu3
+胠 qu1
+胡 hu2
+胢 ke1
+胣 yi3 chi3
+胤 yin4
+胥 xu1 xu3
+胦 yang1
+胧 long2
+胨 dong4
+胩 ka3
+胪 lu2
+胫 jing4 keng1
+胬 nu3 nu2
+胭 yan1
+胮 pang2
+胯 kua4 kua3
+胰 yi2
+胱 guang1
+胲 hai3 gai1 gai3 gei3
+胳 ge1 ge2 ga1
+胴 dong4
+胵 zhi4 chi1
+胶 jiao1 xiao2 jiao3
+胷 xiong1
+胸 xiong1
+胹 er2
+胺 an4 e4
+胻 xing2 heng2
+胼 pian2
+能 neng2 nai4 tai2 tai4 nai2 xiong2
+胾 zi4
+脀 cheng2 zheng1
+脁 tiao4 tiao3
+脂 zhi1 zhi3
+脃 cui4
+脄 mei2
+脅 xie2 xian4 xi1
+脆 cui4
+脇 xie2
+脈 mai4 mo4
+脉 mai4 mo4
+脊 ji2 ji3
+脍 kuai4
+脎 sa4
+脏 zang1 zang4 zang3
+脐 qi2
+脑 nao3
+脒 mi3
+脓 nong2
+脔 luan2 ji1
+脕 wan3 wan4
+脖 bo2
+脗 wen3
+脘 guan3 wan3 huan4
+脙 qiu2
+脚 jiao3 jue2
+脛 jing4 keng1
+脜 rou2
+脝 heng1
+脞 cuo3 qie1
+脟 lie4 le4 luan2
+脠 shan1 chan1
+脡 ting3
+脢 mei2
+脣 chun2
+脤 shen4
+脥 qian3 qu1 jia2 xie2
+脦 te4
+脧 zui1 juan1
+脨 cu4
+脩 xiu1 tiao2
+脪 xin4
+脫 tuo1 tui4
+脬 pao1 bao1
+脭 cheng2
+脮 nei3
+脯 fu3 pu2
+脰 dou4
+脱 tuo1
+脲 niao4
+脴 pi3
+脵 gu3
+脶 gua1 luo2
+脷 li4
+脸 lian3
+脹 zhang4 chang2
+脺 cui4
+脻 jie2
+脼 liang3
+脽 zhou1 shui2
+脾 pi2 pai2 bi4 pi4
+脿 biao1 biao4 biao3
+腀 lun2
+腁 pian2
+腂 guo4
+腃 kui4 quan1 quan2 juan4
+腄 chui2 hou2 chuai2
+腅 dan4
+腆 tian3
+腇 nei3
+腈 jing1
+腉 jie1
+腊 la4 xi1
+腋 ye4 yi4
+腌 yan1 a1 ang1 an1
+腍 ren3 ren4
+腎 shen4
+腏 chuo4 zhui4
+腐 fu3
+腑 fu3
+腒 ju1
+腓 fei2
+腔 qiang1 kong4
+腕 wan4
+腖 dong4
+腗 pi2 pai2 pi4
+腘 guo2
+腙 zong1
+腚 ding4
+腛 wu1
+腜 mei2
+腝 ruan3 er2 nao4
+腞 zhuan4 dun4 tu2
+腟 zhi4
+腠 cou4
+腡 gua1 luo2
+腢 ou3
+腣 di4
+腤 an1
+腥 xing1
+腦 nao3 nao4
+腧 yu2 shu4
+腨 chuan3
+腩 nan3
+腪 yun4
+腫 zhong3
+腬 rou2
+腭 e4
+腮 sai1
+腯 tu2
+腰 yao1
+腱 jian4 qian2
+腲 wei3
+腳 jiao3 jue2
+腴 yu2
+腵 jia1
+腶 duan4
+腷 bi4
+腸 chang2
+腹 fu4
+腺 xian4
+腻 ni4
+腼 mian3
+腽 wa4
+腾 teng2
+腿 tui3
+膀 bang3 bang4 pang1 pang2 pang3
+膁 qian1 lian2
+膂 lv3
+膃 wa4
+膄 sou4
+膅 tang2
+膆 su4
+膇 zhui4
+膈 ge2
+膉 yi4
+膊 bo2 po4 lie4
+膋 liao2
+膌 ji2
+膍 pi2
+膎 xie2
+膏 gao1 gao4
+膐 lv3
+膑 bin4
+膓 chang2
+膔 lu4
+膕 guo2
+膖 pang1
+膗 chuai2
+膘 piao3 biao1
+膙 jiang3
+膚 fu1
+膛 tang2 tang1
+膜 mo4 mo2
+膝 xi1
+膞 zhuan1 chun2
+膟 lv4
+膠 jiao1 jiao3
+膡 ying4
+膢 lv2 liu2 lou2
+膣 zhi4
+膥 chun1
+膦 lian3 lin4
+膧 tong2
+膨 peng2 peng4
+膩 ni4
+膪 zha4 zhai4
+膫 liao2
+膬 cui4
+膭 gui1
+膮 xiao1
+膯 teng1
+膰 fan2
+膱 zhi2 zhu1
+膲 jiao1
+膳 shan4
+膴 hu1 wu3 mei2 wu2
+膵 cui4
+膶 run4
+膷 xiang1
+膸 sui3
+膹 fen4
+膺 ying1
+膻 dan4 shan1 tan3
+膼 zhua1
+膽 dan3
+膾 kuai4
+膿 nong2
+臀 tun2
+臁 lian2
+臂 bi4 bei5 bei4
+臃 yong3 yong1
+臄 jue2
+臅 chu4
+臆 yi4 yi3
+臇 juan3
+臈 la4
+臉 lian3
+臊 sao1 sao4
+臋 tun2
+臌 gu3
+臍 qi2
+臎 cui4
+臏 bin4
+臐 xun1
+臑 ru2 er2 nao4
+臒 huo4
+臓 zang4
+臔 xian4
+臕 biao1 piao3
+臖 xing4
+臗 kuan1
+臘 la4
+臙 yan1
+臚 lu2 lv3
+臛 huo4
+臜 zang1 za1 zan1
+臝 luo3
+臞 qu2
+臟 zang4
+臠 luan2
+臡 ni2
+臢 zang1 za1 zan1
+臣 chen2
+臤 qian1
+臥 wo4
+臦 guang4
+臧 zang1 cang2 zang4 zang2
+臨 lin2 lin4
+臩 guang4
+自 zi4
+臫 jiao3
+臬 nie4
+臭 chou4 xiu4
+臮 ji4
+臯 gao1
+臰 chou4
+臱 mian2
+臲 nie4
+至 zhi4 die2
+致 zhi4 zhui4
+臵 ge2
+臶 jian4 zun4
+臷 die2
+臸 zhi4
+臹 xiu1
+臺 tai2 yi2 tai1
+臻 zhen1
+臼 jiu4
+臽 xian4
+臾 yu2 yong3 yu3 kui4
+臿 cha1
+舀 yao3
+舁 yu2
+舂 chong1 chuang1 zhong1
+舃 xi4 qiao3 tuo1 que4
+舄 xi4 qiao3
+舅 jiu4
+舆 yu2
+與 yu3 yu4 yu2
+興 xing1 xing4
+舉 ju3
+舊 jiu4
+舋 xin4 wen4
+舌 she2 gua1
+舍 she4 she3 shi4
+舏 jiu3
+舐 shi4
+舑 tan1
+舒 shu1 yu4
+舓 shi4
+舔 tian3 tan1
+舕 dan4 tan4
+舖 pu4 pu1
+舗 pu4 pu1
+舘 guan3
+舙 hua4
+舚 tan1 tian4
+舛 chuan3
+舜 shun4
+舝 xia2
+舞 wu3
+舟 zhou1
+舠 dao1
+舡 gang1 chuan2 xiang1
+舢 shan1
+舣 yi3
+舥 pa1
+舦 tai4
+舧 fan2
+舨 ban3
+舩 chuan2
+航 hang2
+舫 fang3
+般 ban1 bo1 pan2 ban3
+舭 que4 bi3
+舯 zhong1
+舰 jian4
+舱 cang1
+舲 ling2
+舳 zhu2 zhou4
+舴 ze2
+舵 duo4 tuo2
+舶 bo2
+舷 xian2
+舸 ge3
+船 chuan2
+舺 xia2 jia2 jia3
+舻 lu3 lu2
+舼 hong2
+舽 pang2
+舾 xi1
+艀 fu2
+艁 zao4
+艂 feng2
+艃 li2
+艄 shao1 shao4
+艅 yu2
+艆 lang2
+艇 ting3
+艉 wei3
+艊 bo2
+艋 meng3
+艌 nian4
+艍 ju1
+艎 huang2
+艏 shou3
+艐 zong1
+艑 bian4
+艒 mao4 mu4
+艓 die2
+艕 bang4
+艖 cha1
+艗 yi4
+艘 sao1 sou1
+艙 cang1
+艚 cao2
+艛 lou2
+艜 dai4
+艞 yao4
+艟 tong2 chong1 zhuang4
+艡 dang1
+艢 tan2 qiang2
+艣 lu3
+艤 yi3
+艥 jie4
+艦 jian4
+艧 huo4
+艨 meng2
+艩 qi2
+艪 lu3
+艫 lu2 lu3
+艬 chan2
+艭 shuang1
+艮 gen4 gen3 hen2
+良 liang2 liang3
+艰 jian1
+艱 jian1
+色 se4 shai3
+艳 yan4
+艴 fu2 bo2 pei4
+艵 ping2
+艶 yan4
+艷 yan4
+艸 cao3 zao4
+艺 yi4
+艻 le4 ji2
+艼 ting1 ding3
+艽 qiu2 jiu3 jiao1
+艾 ai4 yi4
+艿 nai3 reng2 reng4
+芀 tiao2
+芁 jiao1
+节 jie2 jie1
+芃 peng2
+芄 wan2
+芅 yi4
+芆 chai1
+芇 mian2
+芈 mie1 mi3
+芉 gan1
+芊 qian1 qian4
+芋 yu4 hu1 xu1 yu3 yu2
+芌 yu4 yu2 xu1 yu3
+芍 shao2 xiao4 que4 shuo4 di4
+芎 qiong1 xiong1
+芏 tu3 du4
+芐 xia4 hu4
+芑 qi3
+芒 mang2 wang2 huang3 huang1
+芓 zi3 zi4
+芔 hui3 hui4
+芕 sui1 wei3
+芖 zhi4
+芗 xiang1 xiang3
+芘 pi2 bi4 bi1
+芙 fu2
+芚 tun2 chun1
+芛 wei3
+芜 wu2
+芝 zhi1
+芞 qi3
+芟 shan1 wei3
+芠 wen2
+芡 qian4
+芢 ren2
+芣 fu2 fou3 fu1 fou2
+芤 kou1
+芥 jie4 gai4
+芦 lu2 lu3
+芧 xu4 zhu4
+芨 ji2 ji1
+芩 qin2 yin2
+芪 qi2 chi2
+芫 yuan2 yan2
+芬 fen1 fen2
+芭 ba1 pa1
+芮 rui4 ruo4
+芯 xin1 xin4
+芰 ji4
+花 hua1
+芲 hua1
+芳 fang1
+芴 wu4 hu1
+芵 jue2
+芶 gou1
+芷 zhi3
+芸 yun2 yi4 yun4
+芹 qin2
+芺 ao3
+芻 chu2
+芼 mao4 mao2
+芽 ya2
+芾 fei4 fu4 fu2
+芿 reng4
+苀 hang2
+苁 cong1
+苂 yin2
+苃 you3
+苄 bian4
+苅 yi4
+苇 wei3
+苈 li4
+苉 pi3
+苊 e4
+苋 xian4 huan2
+苌 chang2
+苍 cang1 cang3
+苎 meng2 zhu4
+苏 su1
+苐 yi2 ti2 di4
+苑 yuan4 yuan3 yu4 yun3 yun1 yuan1
+苒 ran3
+苓 ling2 lian2
+苔 tai2 tai1
+苕 tiao2 shao2
+苖 di3
+苗 miao2
+苘 qiong3 qing3
+苙 li4
+苚 yong4
+苛 ke1 he1 he2
+苜 mu4
+苝 pei4
+苞 bao1 pao2 biao1
+苟 gou3 gou1
+苠 min2
+苡 yi3 si4
+苢 yi3
+苣 ju4 qu3
+苤 pi1 pie3 pi3
+若 ruo4 re3 re2 re4
+苦 ku3 gu3
+苧 zhu4 ning2
+苨 ni3
+苩 bo2
+苪 bing3
+苫 shan1 shan4 tian1 chan1
+苬 xiu2
+苭 yao3
+苮 xian1
+苯 ben3
+苰 hong2
+英 ying1 yang1
+苲 zha3 zha4 zuo2
+苳 dong1
+苴 ju1 cha2 zha3 zu1 jie1 bao1 xie2
+苵 die2
+苶 nie2
+苷 gan1
+苸 hu1
+苹 ping2 pin2 peng1
+苺 mei2 mei4
+苻 fu2 pu2
+苼 sheng1
+苽 gu1
+苾 bi4
+苿 wei4
+茀 fu2 bo2
+茁 zhuo2 zhu2
+茂 mao4
+范 fan4
+茄 qie2 jia1
+茅 mao2
+茆 mao3 mao2
+茇 ba2 pei4
+茈 zi3 chai2 ci2 ci3
+茉 mo4
+茊 zi1 ci2
+茋 di3
+茌 chi2
+茍 ji4
+茎 jing1
+茏 long2
+茑 niao3
+茓 xue2
+茔 ying2
+茕 qiong2
+茖 ge2 ge4
+茗 ming2 ming3
+茘 li4
+茙 rong2
+茚 yin4
+茛 gen4 jian4
+茜 qian4 qian1 xi1
+茝 chai3 zhi3
+茞 chen2
+茟 yu4
+茠 xiu1 hao1
+茡 zi4
+茢 lie4
+茣 wu2
+茤 ji4 duo1
+茥 gui1 gui4 kui1
+茦 ce4
+茧 chong2 jian3
+茨 ci2
+茩 gou3 hou4
+茪 guang1
+茫 mang2 huang3
+茬 chi2 cha2
+茭 jiao1 xiao3 xiao4 qiao4
+茮 jiao1
+茯 fu2
+茰 yu2
+茱 zhu1
+茲 zi1 ci1
+茳 jiang1
+茴 hui2
+茵 yin1
+茶 cha2
+茷 fa2 fei4
+茸 rong2 rong3
+茹 ru2
+茺 chong1
+茻 mang3
+茼 tong2
+茽 zhong4
+茿 zhu2
+荀 xun2
+荁 huan2
+荂 kua1
+荃 quan2 chuo4
+荄 gai1
+荅 da1 da2 ta4
+荆 jing1
+荇 xing4
+荈 chuan3 quan4
+草 cao3 zao4
+荊 jing1
+荋 er2
+荌 an4
+荍 shou1 qiao2
+荎 chi2
+荏 ren3
+荐 jian4
+荑 ti2 yi2
+荒 huang1 huang3 kang1
+荓 ping2 ping1
+荔 li4
+荕 jin1
+荖 lao3 cha1
+荗 shu4
+荘 zhuang1
+荙 da2
+荚 jia2
+荛 rao2 yao2
+荜 bi4
+荝 ze2 ce4
+荞 qiao2 jiao1
+荟 hui4
+荠 qi2 ji4 qi5
+荡 dang4
+荣 rong2
+荤 hun1 xun1
+荥 ying2
+荦 luo4
+荧 ying2
+荨 xun2 qian2 tan2
+荩 jin4
+荪 sun1
+荫 yin4 yin1
+荬 mai3
+荭 hong2
+荮 zhou4
+药 yao4 yue4
+荰 du4
+荱 wei3
+荲 chu4
+荳 dou4
+荴 fu1
+荵 ren3
+荶 yin2
+荷 he2 he4 ke1 he1
+荸 bi2 bo2
+荹 bu4
+荺 yun2 yun3
+荻 di2
+荼 tu2 cha2 shu1 ye2
+荽 sui1 wei1 wei3
+荾 sui1
+荿 cheng2
+莀 chen2
+莁 wu2
+莂 bie2
+莃 xi1
+莄 geng3
+莅 li4
+莆 fu3 pu2
+莇 zhu4
+莈 mo4
+莉 li4 li2 chi2
+莊 zhuang1
+莋 ji2 zuo2
+莌 duo2 tuo4
+莍 qiu2
+莎 sha1 suo1 sui1
+莏 suo1
+莐 chen2
+莑 feng1
+莒 ju3
+莓 mei2 mei4
+莔 meng2
+莕 xing4
+莖 jing1 ying1
+莗 che1
+莘 shen1 xin1
+莙 jun1
+莚 yan2
+莛 ting2 ting3
+莜 you2 diao4 di2
+莝 cuo4
+莞 guan1 guan3 wan3
+莟 han4
+莠 you3 xiu4
+莡 cuo4
+莢 jia2
+莣 wang2
+莤 you2
+莥 niu3
+莦 shao1
+莧 xian4 huan2 wan4
+莨 lang2 lang4 liang2
+莩 fu2 piao3
+莪 e2
+莫 mo4 mu4
+莬 wen4 wan3 mian3
+莭 jie2
+莮 nan2
+莯 mu4
+莰 kan3
+莱 lai2
+莲 lian2
+莳 shi2 shi4
+莴 wo1
+莶 lian3 lian2 xian1
+获 huo4
+莸 you2
+莹 ying2
+莺 ying1
+莼 chun2
+莽 mang3 mang2
+莾 mang3
+莿 ci4
+菀 wan3 yuan4 yu4 yun4
+菁 jing1
+菂 di1 di4
+菃 qu2
+菄 dong1
+菅 jian1 guan1
+菆 zou1
+菇 gu1
+菈 la1
+菉 lu4
+菊 ju2
+菋 wei4
+菌 jun1 jun4
+菍 nie4
+菎 kun1 jun4
+菏 he2 ge1
+菐 pu2
+菑 zi1 zai1 zi4
+菒 gao3
+菓 guo3
+菔 fu2 bo2
+菕 lun2 lun4
+菖 chang1
+菗 chou2
+菘 song1
+菙 chui2
+菚 zhan4
+菛 men2
+菜 cai4
+菝 ba2 bi4
+菞 li2
+菟 tu4 tu2
+菠 bo1
+菡 han4
+菢 bao4
+菣 qin4
+菤 juan3
+菥 xi1 si1
+菦 qin2
+菧 di3
+菨 jie1
+菩 pu2 bei4 bu4 bo2
+菪 dang4
+菫 jin3 jin4 qin2
+菬 zhao3
+菭 tai2
+菮 geng1
+華 hua2 hua1 hua4
+菰 gu1
+菱 ling2
+菲 fei1 fei3 fei4
+菳 jin1
+菴 an1 an3
+菵 wang3
+菶 beng3 peng2
+菷 zhou3
+菸 yan1 yu1 yu4
+菹 ju1 zu1 ju4
+菺 jian1
+菻 lin3 ma2
+菼 tan3
+菽 shu2 shu1 jiao1
+菾 tian2
+菿 dao4
+萀 hu3
+萁 qi2 ji1
+萂 he2
+萃 cui4
+萄 tao2
+萅 chun1 chun3
+萆 pi4 bi4 bei1 ba2
+萇 chang2
+萈 huan2
+萉 fei2
+萊 lai2
+萋 qi1
+萌 meng2 ming2
+萍 ping2
+萎 wei1 wei3
+萏 dan4
+萐 sha4
+萑 huan2 tui1 zhui1
+萒 yan3
+萓 yi2
+萔 tiao2
+萕 qi2
+萖 wan3
+萗 ce4
+萘 nai4
+萚 tuo4
+萛 jiu1
+萜 tie1
+萝 luo2
+萠 meng2
+萤 ying2
+营 ying2
+萦 ying2
+萧 xiao1
+萨 sa4
+萩 qiu1
+萪 ke1
+萫 xiang4
+萬 wan4
+萭 yu3 ju3
+萮 yu4
+萯 fu4
+萰 lian4
+萱 xuan1
+萲 yuan2 xuan1
+萳 nan2
+萴 ze2 ce4
+萵 wo1
+萶 chun3
+萷 xiao1
+萸 yu2
+萹 pian1 bian1
+萺 mao4
+萻 an1
+萼 e4
+落 luo4 la4 lao4 luo1
+萾 ying2
+萿 huo2
+葀 gua1
+葁 jiang1
+葂 mian3
+葃 zuo2
+葄 zuo4
+葅 ju1 zu1
+葆 bao3 bao1
+葇 rou2
+葈 xi3
+葉 ye4 xie2 she4
+葊 an1
+葋 qu2
+葌 jian1
+葍 fu2
+葎 lv4
+葏 jing1
+葐 pen2
+葑 feng1 feng4
+葒 hong2
+葓 hong2
+葔 hou2
+葕 yan2
+葖 tu2 tu1
+著 zhu4 zhuo2 chu2 zhao1 zhao2 zhe5
+葘 zi1
+葙 xiang1
+葚 shen4 ren4
+葛 ge2 ge3
+葜 jie2 qia1
+葝 jing4
+葞 mi3
+葟 huang2
+葠 shen1
+葡 pu2 bei4
+葢 gai4 ge3 he2
+董 dong3 zhong3
+葤 zhou4
+葥 qian2
+葦 wei3
+葧 bo2
+葨 wei1
+葩 pa1
+葪 ji4 jie4
+葫 hu2
+葬 zang4
+葭 jia1 xia2
+葮 duan4
+葯 yao4 yue4
+葰 jun4 sui1
+葱 cong1 chuang1
+葲 quan2
+葳 wei1
+葴 zhen1 qian2 xian2
+葵 kui2
+葶 ting2 ding3
+葷 hun1 xun1
+葸 xi3
+葹 shi1
+葺 qi4
+葻 lan2
+葼 zong1
+葽 yao1
+葾 yuan1
+葿 mei2
+蒀 yun1
+蒁 shu4
+蒂 di4
+蒃 zhuan4
+蒄 guan1
+蒆 xue1
+蒇 chan3
+蒈 kai3
+蒉 kui4 kuai4
+蒋 jiang3 jiang1
+蒌 lou2 liu3
+蒍 wei2 wei3
+蒎 pai4
+蒐 sou1
+蒑 yin1
+蒒 shi1
+蒓 chun2
+蒔 shi2 shi4
+蒕 yun1
+蒖 zhen1
+蒗 lang4
+蒘 nu2
+蒙 meng2 meng1 meng3 mang2
+蒚 he2
+蒛 que1
+蒜 suan4
+蒝 yuan2
+蒞 li4
+蒟 ju3
+蒠 xi2 xi1
+蒡 bang4 pang2
+蒢 chu2
+蒣 xu2
+蒤 tu2
+蒥 liu2
+蒦 wo4 yue1
+蒧 zhen1 dian3
+蒨 qian4
+蒩 zu1
+蒪 po4
+蒫 cuo1
+蒬 yuan1
+蒭 chu2
+蒮 yu4
+蒯 kuai3 kuai4
+蒰 pan2
+蒱 pu2
+蒲 pu2 bo2
+蒳 na4
+蒴 shuo4
+蒵 xi1 xi2 xi4
+蒶 fen2
+蒷 yun2
+蒸 zheng1
+蒹 jian1
+蒺 ji2
+蒻 ruo4
+蒼 cang1 cang3
+蒽 en1
+蒾 mi2
+蒿 hao1 gao3
+蓀 sun1
+蓁 zhen1 qin2
+蓂 ming2
+蓃 huo4
+蓄 xu4
+蓅 liu2
+蓆 xi2
+蓇 gu3 gu1
+蓈 lang2
+蓉 rong2
+蓊 weng3 weng4
+蓋 gai4 ge3 he2
+蓌 cuo4
+蓍 shi1
+蓎 tang2
+蓏 luo3
+蓐 ru4
+蓑 suo1 sai1 sui1
+蓒 xian1
+蓓 bei4
+蓔 yao3
+蓕 gui4
+蓖 bi4 bi1
+蓗 zong3
+蓘 gun3
+蓚 xiu1
+蓛 ce4
+蓝 lan2 la5
+蓟 ji4
+蓠 li2
+蓡 can1 shen1
+蓢 lang2
+蓣 yu4
+蓥 ying4 ying2
+蓦 mo4
+蓧 diao4 tiao1 tiao2
+蓨 tiao1 tiao2
+蓩 mao4
+蓪 tong1
+蓫 zhu2
+蓬 peng2 peng4
+蓭 an1
+蓮 lian2 lian3
+蓯 cong1
+蓰 xi3
+蓱 ping2
+蓲 qiu1 xu1
+蓳 jin4
+蓴 chun2
+蓵 jie2
+蓶 wei3
+蓷 tui1
+蓸 cao2
+蓹 yu3
+蓺 yi4
+蓻 ji2
+蓼 liao3 lu4 lao3 liu3
+蓽 bi4
+蓾 lu3
+蓿 su4 xu4
+蔀 bu4 pou3
+蔁 zhang1
+蔂 luo2
+蔃 jiang4
+蔄 man4
+蔅 yan2
+蔆 ling2
+蔇 ji4 xi4
+蔈 piao3 biao1
+蔉 gun3
+蔊 han3 han4
+蔋 di2
+蔌 su4
+蔍 lu4
+蔎 she4
+蔏 shang1
+蔐 di2
+蔑 mie4
+蔒 xun1
+蔓 man4 wan4 man2
+蔔 bo5 bo2
+蔕 di4
+蔖 cuo2
+蔗 zhe4
+蔘 sen1 san1 shen1
+蔙 xuan4
+蔚 wei4 yu4
+蔛 hu2
+蔜 ao2
+蔝 mi3
+蔞 lou2 liu3 ju4 lv3
+蔟 cu4 cou4 chuo4
+蔠 zhong1
+蔡 cai4 sa4 ca1
+蔢 po2
+蔣 jiang3 jiang1
+蔤 mi4
+蔥 cong1
+蔦 niao3
+蔧 hui4 sui4
+蔨 jun4
+蔩 yin2
+蔪 jian4
+蔫 yan1 nian1 yan4
+蔬 shu1 xu1 shu3
+蔭 yin4 yin1
+蔮 kui4
+蔯 chen2
+蔰 hu4
+蔱 sha1
+蔲 kou4
+蔳 qian4
+蔴 ma2
+蔵 zang1 cang2
+蔷 qiang2 se4
+蔸 dou1
+蔹 lian4 lian2
+蔺 lin4
+蔻 kou4
+蔼 ai3
+蔽 bi4 fu4
+蔾 li2
+蔿 wei2
+蕀 ji2
+蕁 xun2 qian2 tan2
+蕂 sheng4
+蕃 fan2 fan1 bo2 pi2 bo1
+蕄 meng2
+蕅 ou3
+蕆 chan3
+蕇 dian3
+蕈 xun4 tan2
+蕉 jiao1 qiao2 qiao1
+蕊 rui3 juan3
+蕋 rui3
+蕌 lei3
+蕍 yu2
+蕎 qiao2 jiao1
+蕏 chu2 zhu1 zha1
+蕐 hua2
+蕑 jian1
+蕒 mai3
+蕓 yun2
+蕔 bao1
+蕕 you2
+蕖 qu2
+蕗 lu4
+蕘 rao2 yao2
+蕙 hui4
+蕚 e4
+蕛 teng2 ti2
+蕜 fei3
+蕝 jue2 zui4
+蕞 zui4 jue2 zhuo2
+蕟 fa4 fei4
+蕠 ru2
+蕡 fen2
+蕢 kui4 kuai4
+蕣 shun4
+蕤 rui2
+蕥 ya3
+蕦 xu1
+蕧 fu4
+蕨 jue2
+蕩 dang4 tang1 tang4
+蕪 wu2 wu3
+蕫 tong2 dong3
+蕬 si1
+蕭 xiao1
+蕮 xi4
+蕯 long2
+蕰 yun4 wen1
+蕲 qi2
+蕳 jian1
+蕴 yun4
+蕵 sun1
+蕶 ling2
+蕷 yu4
+蕸 xia2
+蕹 yong1 weng4
+蕺 ji2 qie4
+蕻 hong4 hong2
+蕼 si4
+蕽 nong2
+蕾 lei3
+蕿 xuan1
+薀 yun4
+薁 yu4
+薂 xi2
+薃 hao4 hao3
+薄 bo2 bao2 bo4 bu4
+薅 hao1
+薆 ai4
+薇 wei2 wei1
+薈 hui4
+薉 wei4 hui4
+薊 ji4
+薋 ci1 ci2
+薌 xiang1 xiang3
+薍 luan4 wan4
+薎 mie4
+薏 yi4
+薐 leng2
+薑 jiang1
+薒 can4
+薓 shen1
+薔 qiang2 se4
+薕 lian2
+薖 ke1
+薗 yuan2
+薘 da2
+薙 ti4
+薚 tang2
+薛 xue1 xie1
+薜 bi4 bo4 bo2 bai4 pi4
+薝 zhan2
+薞 sun1
+薟 lian3 lian2 xian1 yan2 kan4
+薠 fan2
+薡 ding3
+薢 jie1 xie4
+薣 gu3
+薤 xie4
+薥 shu3
+薦 jian4
+薧 kao3 hao1
+薨 hong1
+薩 sa4
+薪 xin1
+薫 xun1
+薬 yao4
+薮 sou3
+薯 shu3
+薰 xun1
+薱 dui4
+薲 pin2
+薳 wei3
+薴 neng2 ning4
+薵 chou2 zhou4
+薶 mai2 li2 wei1 wo1
+薷 ru2
+薸 piao1
+薹 tai2
+薺 ci2 ji4 qi4 qi2 qi5
+薻 zao3
+薼 chen2
+薽 zhen1
+薾 er3
+薿 ni3
+藀 ying2
+藁 gao3
+藂 cong4 cong2
+藃 xiao1 hao4
+藄 qi2
+藅 fa2
+藆 jian3
+藇 xu4 yu4
+藈 kui1
+藉 jie4 ji2
+藊 bian3
+藋 diao4 di2
+藌 mi4
+藍 lan2 la5
+藎 jin4
+藏 cang2 zang4 zang1
+藐 miao3 mo4
+藑 qiong2
+藒 qie4
+藓 xian3
+藕 ou3
+藖 xian2
+藗 su4
+藘 lv2
+藙 yi4
+藚 xu4
+藛 xie3
+藜 li2
+藝 yi4
+藞 la3
+藟 lei3
+藠 xiao4 jiao4
+藡 di2
+藢 zhi3
+藣 bei1
+藤 teng2
+藥 yao4 yue4 shuo4 lve4
+藦 mo4 mo2
+藧 huan3
+藨 biao1 pao1 piao3
+藩 fan2 fan1
+藪 sou3 shu2 cou4
+藫 tan2
+藬 tui1
+藭 qiong2
+藮 qiao2
+藯 wei4
+藰 liu2
+藱 hui4 hui2
+藳 gao3 kao4 gao4
+藴 yun4
+藶 li4
+藷 shu3
+藸 chu2
+藹 ai3
+藺 lin4
+藻 zao3
+藼 xuan1
+藽 chen4
+藾 lai4
+藿 huo4 he2
+蘀 tuo4
+蘁 wu4 e4
+蘂 rui3
+蘃 rui3
+蘄 qi2 ji1 qin2
+蘅 heng2
+蘆 lu2
+蘇 su1 su4
+蘈 tui2
+蘉 mang2
+蘊 yun4 wen1
+蘋 pin2 ping2
+蘌 yu3
+蘍 xun1
+蘎 ji4
+蘏 jiong1 jiong3
+蘐 xian1 xuan1
+蘑 mo2
+蘓 su1
+蘔 jiong1 jiong3
+蘖 nie4 bi4 bo4
+蘗 bo4
+蘘 rang2
+蘙 yi4
+蘚 xian3
+蘛 yu2
+蘜 ju2
+蘝 lian4 lian3 lian2
+蘞 lian4 lian3 lian2 xian1
+蘟 yin3
+蘠 qiang2
+蘡 ying1
+蘢 long2 long3 long4
+蘣 tong4
+蘤 wei3 hua1
+蘥 yue4
+蘦 ling2
+蘧 qu2 qu4
+蘨 yao2
+蘩 fan2
+蘪 mi2
+蘫 lan2
+蘬 kui1
+蘭 lan2
+蘮 ji4
+蘯 dang4
+蘱 lei4
+蘲 lei2
+蘳 hua3
+蘴 feng1
+蘵 zhi2
+蘶 wei4
+蘷 kui2
+蘸 zhan4
+蘹 huai4 huai2
+蘺 li2
+蘻 ji4
+蘼 mi2
+蘽 lei3
+蘾 huai4
+蘿 luo2
+虀 ji1
+虁 kui2
+虂 lu4
+虃 jian1
+虆 lei2
+虇 quan3
+虈 xiao1
+虉 yi4
+虊 luan2
+虋 men2
+虌 bie1
+虍 hu1
+虎 hu3 hu4
+虏 lu3
+虐 nue4
+虑 lv4
+虒 si1 zhai4 yi2
+虓 xiao1
+虔 qian2
+處 chu4 chu3
+虖 hu1 hu4 hu2
+虗 xu1
+虘 cuo2
+虙 fu2
+虚 xu1 qu1
+虛 xu1
+虜 lu3
+虝 hu3
+虞 yu2
+號 hao4 hao2
+虠 jiao3
+虡 ju4
+虢 guo2
+虣 bao4
+虤 yan2
+虥 zhan4
+虦 zhan4
+虧 kui1
+虨 ban1
+虩 xi4
+虪 shu2 shu1
+虫 chong2 hui3
+虬 qiu2
+虭 diao1
+虮 ji1 ji3 qi2
+虯 qiu2
+虰 cheng2
+虱 shi1
+虳 di4
+虴 zhe2 zha4
+虵 she2 yi2
+虶 yu1
+虷 gan1 han2
+虸 zi3
+虹 hong2 jiang4 hong4 gong4
+虺 hui3 hui1
+虻 meng2
+虼 ge4
+虽 sui1
+虾 xia1 ha2
+虿 chai4
+蚀 shi2
+蚁 yi3
+蚂 ma3 ma1 ma4
+蚃 xiang4 xiang3
+蚄 fang1
+蚅 e4
+蚆 pa1
+蚇 chi3
+蚈 qian1
+蚉 wen2
+蚊 wen2
+蚋 rui4
+蚌 bang4 beng4 pi2 feng1
+蚍 bi3 pi2
+蚎 yue4
+蚏 yue4
+蚐 jun1
+蚑 qi2
+蚒 tong2 ran2
+蚓 yin3
+蚔 qi2
+蚕 can2 tian3
+蚖 yuan2
+蚗 jue2
+蚘 hui2
+蚙 qin2
+蚚 qi2
+蚛 zhong4
+蚜 ya2
+蚝 ci4 hao2
+蚞 mu4
+蚟 wang2
+蚠 fen2
+蚡 fen2
+蚢 hang2
+蚣 gong1 zhong1
+蚤 zao3 zhao3
+蚥 fu3
+蚦 ran2 tian4
+蚧 jie4
+蚨 fu2
+蚩 chi1
+蚪 dou3
+蚫 piao2
+蚬 xian4 xian3
+蚭 ni2
+蚮 te4
+蚯 qiu1
+蚰 you2 zhu2
+蚱 zha4
+蚲 ping2
+蚳 chi2
+蚴 you3 you4 niu4 you1
+蚵 he2 ke4
+蚶 han1
+蚷 ju4 qu2
+蚸 li4
+蚹 fu4
+蚺 ran2 tian4
+蚻 zha2
+蚼 gou3
+蚽 pi2
+蚾 bo3
+蚿 xian2
+蛀 zhu4
+蛁 diao1
+蛂 bie3 bie2
+蛃 bing3
+蛄 gu1 gu3
+蛅 ran2 zhan1
+蛆 qu1 ju1
+蛇 she2 yi2 tuo2 chi2
+蛈 tie4
+蛉 ling2
+蛊 gu3
+蛋 dan4
+蛌 gu3
+蛍 ying2
+蛎 li4
+蛏 cheng1
+蛐 qu1
+蛑 mou2
+蛒 ge2
+蛓 ci4
+蛔 hui2
+蛕 hui2
+蛖 mang2
+蛗 fu4
+蛘 yang2 yang3
+蛙 wa1 jue2
+蛚 lie4
+蛛 zhu1
+蛜 yi1
+蛝 xian2
+蛞 kuo4 she2
+蛟 jiao1
+蛠 li4
+蛡 yi4
+蛢 ping2
+蛣 jie2 qie4 ji1
+蛤 ha2 ge2 ha1 e4
+蛥 she2
+蛦 yi2
+蛧 wang3
+蛨 mo4
+蛩 qiong2 gong3
+蛪 qie4
+蛫 gui3
+蛬 gong3 qiong2
+蛭 zhi4
+蛮 man2
+蛰 zhe2 zhi2
+蛱 jia2
+蛲 rao2
+蛳 si1
+蛴 qi2
+蛵 xing1
+蛶 lie4
+蛷 qiu2
+蛸 shao1 xiao1
+蛹 yong3
+蛺 jia2
+蛻 tui4 yue4 shui4
+蛼 che1
+蛽 bai4
+蛾 e2 yi3
+蛿 han4
+蜀 shu3
+蜁 xuan2
+蜂 feng1
+蜃 shen4
+蜄 zhen4
+蜅 fu3
+蜆 xian4 xian3
+蜇 zhe2 zhe1
+蜈 wu2
+蜉 fu2
+蜊 li2
+蜋 lang2
+蜌 bi4
+蜍 chu2 shu2 yu2
+蜎 yuan1 xuan1
+蜏 you3
+蜐 jie2
+蜑 dan4
+蜒 yan2 yan4 dan4
+蜓 ting2 dian4
+蜔 dian4
+蜕 shui4
+蜖 hui2
+蜗 gua1 wo1
+蜘 zhi1
+蜙 song1
+蜚 fei1 fei3 pei4 bei4
+蜛 ju1
+蜜 mi4
+蜝 qi2
+蜞 qi2
+蜟 yu4
+蜠 jun3
+蜡 la4 zha4 cha4 qu4 ji2
+蜢 meng3 meng4
+蜣 qiang1
+蜤 si1
+蜥 xi1
+蜦 lun2
+蜧 li4
+蜨 die2
+蜩 tiao2 diao4
+蜪 tao1
+蜫 kun1
+蜬 gan1
+蜭 han4
+蜮 yu4 guo1
+蜯 bang4
+蜰 fei2
+蜱 pi2 miao2
+蜲 wei3
+蜳 dun1
+蜴 yi4 xi2
+蜵 yuan1
+蜶 su4
+蜷 quan2 juan3
+蜸 qian3
+蜹 rui4
+蜺 ni2
+蜻 qing1 jing1
+蜼 wei4 wei3
+蜽 liang3
+蜾 guo3 luo3
+蜿 wan1 wan3
+蝀 dong1 dong4
+蝁 e4
+蝂 ban3
+蝃 di4
+蝄 wang3
+蝅 can2
+蝆 yang3 yang2
+蝇 ying2
+蝈 guo1
+蝉 chan2
+蝋 la4
+蝌 ke1
+蝍 ji2
+蝎 he2 xie1
+蝏 ting2
+蝐 mai4 mei4
+蝑 xu1
+蝒 mian2
+蝓 yu2
+蝔 jie1
+蝕 shi2 li4 long2
+蝖 xuan1
+蝗 huang2
+蝘 yan3 yan4
+蝙 bian1 pian2
+蝚 rou2
+蝛 wei1
+蝜 fu4
+蝝 yuan2
+蝞 mei4
+蝟 wei4
+蝠 fu2
+蝡 ruan3 ru2
+蝢 xie2
+蝣 you2
+蝤 qiu2 jiu1 you2
+蝥 mao2 mou2 wu2 wu4
+蝦 xia1 ha2 jia3
+蝧 ying1
+蝨 shi1
+蝩 chong2
+蝪 tang1
+蝫 zhu1
+蝬 zong1
+蝭 ti2
+蝮 fu4
+蝯 yuan2
+蝰 hui3 kui2
+蝱 meng2
+蝲 la4
+蝳 du2 dai4
+蝴 hu2
+蝵 qiu1
+蝶 die2 tie1
+蝷 li4
+蝸 gua1 wo1 luo2 guo3
+蝹 yun1
+蝺 ju3
+蝻 nan3 an2
+蝼 lou2
+蝽 qun3
+蝾 rong2
+蝿 ying2
+螀 jiang1
+螂 lang2
+螃 pang2 bang3
+螄 si1
+螅 xi1 ci4
+螆 ci4
+螇 xi1
+螈 yuan2
+螉 weng1
+螊 lian2 xian2
+螋 sou1
+螌 ban1 pan2
+融 rong2
+螎 rong2
+螏 ji2
+螐 wu1
+螑 qiu4
+螒 han4
+螓 qin2
+螔 yi2
+螕 bi1
+螖 hua2
+螗 tang2
+螘 yi3
+螙 du4
+螚 nai4
+螛 he2
+螜 hu2
+螝 hui4
+螞 ma3 ma4 ma1
+螟 ming2
+螠 yi4
+螡 wen2
+螢 ying2
+螣 teng2 te4
+螤 yu3
+螥 cang1
+螨 man3
+螪 shang1
+螫 shi4 zhe1
+螬 cao2
+螭 chi1
+螮 di4
+螯 ao2
+螰 lu4
+螱 wei4
+螲 zhi4 die2
+螳 tang2
+螴 chen2
+螵 piao1 pi2
+螶 qu2
+螷 pi2 beng4 bi4
+螸 yu2
+螹 jian4 chan2
+螺 luo2
+螻 lou2
+螼 qin3
+螽 zhong1
+螾 yin3
+螿 jiang1
+蟀 shuai4
+蟁 wen2
+蟂 jiao1
+蟃 wan4
+蟄 zhe2 zhi2
+蟅 zhe4
+蟆 ma2 mo4
+蟇 ma2
+蟈 guo1 yu4
+蟉 liu2 liao4
+蟊 mao2 meng2
+蟋 xi1
+蟌 cong1
+蟍 li2
+蟎 man3
+蟏 xiao1
+蟑 zhang1
+蟒 mang3 meng3
+蟓 xiang4
+蟔 mo4
+蟕 zui1
+蟖 si1
+蟗 qiu1
+蟘 te4
+蟙 zhi2
+蟚 peng2
+蟛 peng2
+蟜 jiao3
+蟝 qu2
+蟞 bie2
+蟟 liao2
+蟠 pan2 fan2
+蟡 gui3
+蟢 xi3
+蟣 ji3 qi2
+蟤 zhuan1
+蟥 huang2
+蟦 fei4 ben1
+蟧 lao2
+蟨 jue2
+蟩 jue2
+蟪 hui4
+蟫 yin2 tan2 xun2
+蟬 chan2 shan4
+蟭 jiao1
+蟮 shan4
+蟯 rao2 nao2 rao4
+蟰 xiao1
+蟱 mou2
+蟲 chong2
+蟳 xun2
+蟴 si1
+蟶 cheng1
+蟷 dang1
+蟸 li3 li2 luo3 luo2 li4
+蟹 xie4
+蟺 shan4 dan4 chan2 tuo2
+蟻 yi3 ji3
+蟼 jing3
+蟽 da2
+蟾 chan2
+蟿 qi4 ji4
+蠀 ci1
+蠁 xiang4 xiang3
+蠂 she4
+蠃 luo3 luo2 guo3
+蠄 qin2
+蠅 ying2
+蠆 chai4
+蠇 li4
+蠈 ze2
+蠉 xuan1
+蠊 lian2
+蠋 zhu2
+蠌 ze2
+蠍 xie1
+蠎 mang3 meng3
+蠏 xie4
+蠐 qi2
+蠑 rong2
+蠒 jian3
+蠓 meng3
+蠔 hao2
+蠕 ru2 ruan3
+蠖 huo4 yue4
+蠗 zhuo2
+蠘 jie2
+蠙 bin1 pin2
+蠚 he4 he1 ruo4
+蠛 mie4
+蠜 fan2
+蠝 lei2 lei3
+蠞 jie2
+蠟 la4
+蠠 mi4
+蠡 li3 li2 luo2 luo3 li4
+蠢 chun3
+蠣 li4
+蠤 qiu1
+蠥 nie4
+蠦 lu2
+蠧 du4
+蠨 xiao1
+蠩 zhu1
+蠪 long2
+蠫 li4 li2
+蠬 long2
+蠭 feng1
+蠮 ye1
+蠯 beng4
+蠰 shang4 shang1 nang2 rang2
+蠱 gu3
+蠲 juan1
+蠳 ying1
+蠵 xi1 xi2
+蠶 can2
+蠷 qu2
+蠸 quan2
+蠹 du4
+蠺 can2
+蠻 man2
+蠼 jue2 qu2
+蠽 jie2
+蠾 zhu2
+蠿 zha2
+血 xie3 xue4
+衁 huang1
+衂 niu4 nv4
+衃 pei1
+衄 nv4
+衅 xin4
+衆 zhong4
+衇 mo4 mai4
+衈 er4 er3
+衉 ke4
+衊 mie4
+衋 xi4
+行 xing2 hang2 xing4 hang4 heng2
+衍 yan3 yan2
+衎 kan4
+衏 yuan4
+衑 ling2
+衒 xuan4
+術 shu4
+衔 xian2
+衕 tong4 dong4
+衖 long4
+街 jie1
+衘 xian2 yu4
+衙 ya2 yu2 yu3 yu4
+衚 hu2
+衛 wei4
+衜 dao4
+衝 chong1 chong4
+衞 wei4
+衟 dao4
+衠 zhun1
+衡 heng2
+衢 qu2
+衣 yi1 yi4
+补 bu3
+衦 gan3
+衧 yu2
+表 biao3
+衩 cha4 cha3
+衪 yi3 yi4
+衫 shan1
+衬 chen4
+衭 fu1
+衮 gun3
+衯 fen1
+衰 shuai1 cui1 suo1
+衱 jie2
+衲 na4
+衳 zhong1
+衴 dan3
+衵 ri4 ni4
+衶 zhong4 zhong3 chong1
+衷 zhong1 zhong4
+衸 xie4
+衹 qi2 zhi3
+衺 xie2
+衻 ran2
+衼 zhi1
+衽 ren4
+衾 qin1
+衿 jin1 qin4
+袀 jun1
+袁 yuan2
+袂 mei4 yi4
+袃 chai4
+袄 ao3
+袅 niao3
+袆 hui1
+袇 ran2
+袈 jia1
+袉 tuo2
+袊 ling3
+袋 dai4
+袌 bao4
+袍 pao2 bao4
+袎 yao4
+袏 zuo4
+袐 bi4
+袑 shao4
+袒 tan3 zhan4
+袓 ju3
+袔 he4
+袕 shu4
+袖 xiu4
+袗 zhen3 zhen1
+袘 yi2 yi4
+袙 pa4
+袚 bo1 fu2
+袛 di1
+袜 wa4 mo4
+袝 fu4
+袞 gun3
+袟 zhi4
+袠 zhi4
+袡 ran2
+袢 pan4 fan2
+袣 yi4
+袤 mao4 mou2
+袦 na4
+袧 gou1
+袨 xian4 xuan4
+袩 chan1
+袪 qu1
+被 bei4 pi1 bi4 pi4
+袬 gun3
+袭 xi2
+袯 bo2
+袱 fu2
+袲 yi2
+袳 chi3 qi3 duo3 nuo3
+袴 ku4
+袵 ren4
+袶 jiang4
+袷 jia2 jie2
+袸 cun2
+袹 mo4
+袺 jie2
+袻 er2
+袼 luo4 ge1
+袽 ru2
+袾 zhu1
+袿 gui1
+裀 yin1
+裁 cai2
+裂 lie4 lie3
+装 zhuang1
+裆 dang1
+裈 kun1
+裉 ken4
+裊 niao3
+裋 shu4
+裌 jia2
+裍 kun3
+裎 cheng2 cheng3
+裏 li3
+裐 juan1
+裑 shen1
+裒 pou2 bao1
+裓 ge2 jie1
+裔 yi4
+裕 yu4
+裖 zhen3 zhen4
+裗 liu2
+裘 qiu2
+裙 qun2
+裚 ji4
+裛 yi4
+補 bu3
+裝 zhuang1
+裞 shui4
+裟 sha1
+裠 qun2
+裡 li3
+裢 lian2
+裣 lian4 lian3
+裤 ku4
+裥 jian3
+裦 fou2
+裧 chan1
+裨 bi4 pi2
+裩 gun1
+裪 tao2
+裫 yuan4
+裬 ling2
+裭 chi3
+裮 chang1
+裯 chou2 dao1
+裰 duo2 duo1
+裱 biao3
+裲 liang3
+裳 shang5 chang2
+裴 pei2 fei2
+裵 pei2
+裶 fei1
+裷 yuan1 gun3
+裸 luo3
+裹 guo3
+裺 yan3
+裻 du3 du1
+裼 xi2 ti4 xi1
+製 zhi4
+裾 ju1 ju4
+裿 qi3
+褀 ji4
+褁 zhi2
+褂 gua4
+褃 ken4
+褅 ti4
+褆 ti2
+複 fu4
+褈 chong2 chong1 zhong4
+褉 xie1
+褊 bian3 pian1
+褋 die2
+褌 kun1
+褍 duan1
+褎 xiu4 you4
+褏 xiu4 you4
+褐 he2 he4
+褑 yuan4
+褒 bao1
+褓 bao3
+褔 fu4
+褕 yu2
+褖 tuan4
+褗 yan3
+褘 hui1
+褙 bei4
+褚 chu3 zhe3 zhu3
+褛 lv3
+褞 yun3
+褟 da2
+褠 gou1
+褡 da1
+褢 huai2
+褣 rong2
+褤 yuan4
+褥 ru4 nu4
+褦 nai4
+褧 jiong3
+褨 suo3
+褩 ban1
+褪 tun4 tui4
+褫 chi3
+褬 sang3
+褭 niao3
+褮 ying1
+褯 jie4
+褰 qian1
+褱 huai2
+褲 ku4
+褳 lian2
+褴 bao3 lan2
+褵 li2
+褶 zhe2 zhe3 die2 xi2
+褷 shi1
+褸 lv3
+褹 yi4
+褺 die2
+褻 xie4 die2
+褼 xian1
+褽 wei4
+褾 biao3
+褿 cao2
+襀 ji1
+襁 qiang3 jiang3
+襂 sen1 shan1 shen1
+襃 bao1
+襄 xiang1
+襆 pu2 fu2
+襇 jian3
+襈 zhuan4
+襉 jian4
+襊 zui4
+襋 ji2
+襌 dan1
+襍 za2
+襎 fan2
+襏 bo2
+襐 xiang4
+襑 xin2
+襒 bie2
+襓 rao2
+襔 man3
+襕 lan2
+襖 ao3
+襗 duo2 ze4
+襘 gui4
+襙 cao4
+襚 sui4
+襛 nong2
+襜 chan1
+襝 lian4 lian3 chan1
+襞 bi4
+襟 jin1
+襠 dang1
+襡 shu2 shu3 du2
+襢 tan3 zhan4
+襣 bi4 bi2
+襤 lan2
+襥 pu2
+襦 ru2
+襧 zhi3
+襩 shu3
+襪 wa4
+襫 shi4
+襬 bai3
+襭 xie2
+襮 bo2
+襯 chen4
+襰 lai4
+襱 long2 long3
+襲 xi2
+襳 xian1 shen1
+襴 lan2
+襵 zhe2 zhe3
+襶 dai4
+襸 zan4
+襹 shi1
+襺 jian3
+襻 pan4
+襼 yi4
+襾 ya4 xi1
+西 xi1
+覀 xi1
+要 yao4 yao1 yao3
+覂 feng3
+覃 tan2 qin2 yan3
+覅 biao4
+覆 fu4
+覇 ba4 po4
+覈 he2
+覉 ji1
+覊 ji1
+見 jian4 xian4
+覌 guan1 guan4
+覍 bian4 pan2
+覎 yan4
+規 gui1 kui1 xu4 gui4
+覐 jue2 jiao4
+覑 pian3
+覒 mao2
+覓 mi4
+覔 mi4
+覕 mie4 pie1
+視 shi4
+覗 si1 si4
+覘 zhan1 chan1 dan1 ji1
+覙 luo2
+覚 jue2
+覛 mi4 mo4
+覜 tiao4
+覝 lian2
+覞 yao4
+覟 zhi4
+覠 jun1
+覡 xi2
+覢 shan3
+覣 wei1
+覤 xi4
+覥 tian3
+覦 yu2
+覧 lan3
+覨 e4
+覩 du3
+親 qin1 qing4 xin1
+覫 pang3
+覬 ji4
+覭 ming2
+覮 ying2
+覯 gou4
+覰 qu4
+覱 zhan4
+覲 jin3 jin4
+観 guan1
+覴 deng1
+覵 jian4
+覶 luo2
+覷 qu4
+覸 jian4 xian2
+覹 wei2
+覺 jue2 jiao4
+覻 qu4
+覼 luo2
+覽 lan3 lan4
+覾 shen3
+覿 di2 ji2
+觀 guan1 guan4
+见 jian4 xian4
+观 guan1 guan4
+觃 yan4
+规 gui1
+觅 mi4
+视 shi4
+觇 zhan1 chan1
+览 lan3
+觉 jue2 jiao4
+觊 ji4
+觋 xi2
+觌 di2
+觍 tian3
+觎 yu2
+觏 gou4
+觐 jin3
+觑 qu4
+角 jiao3 jue2 gu3 lu4
+觓 jiu1 qiu2
+觔 jin1
+觕 cu1
+觖 jue2 kui4 gui4
+觗 zhi4
+觘 chao4
+觙 ji2 fan2
+觚 gu1
+觛 dan4
+觜 zi1 zui3
+觝 di3
+觞 shang1
+觟 hua4 xie4
+觠 quan2
+觡 ge2
+觢 chi4
+解 jie3 jie4 xie4
+觤 gui3
+觥 gong1
+触 hong2 chu4
+觧 jie3
+觨 hun4
+觩 qiu2
+觪 xing1
+觫 su4
+觬 ni2
+觭 ji1 qi3 qi2
+觮 lu4
+觯 zhi4 zhi1
+觰 zha1 da3 zha3
+觱 bi4
+觲 xing1
+觳 hu2 jue2 que4
+觴 shang1
+觵 gong1
+觶 zhi4 zhi1
+觷 xue2
+觸 chu4
+觹 xi1 wei2
+觺 yi2
+觻 lu4
+觼 jue2
+觽 xi1
+觾 yan4
+觿 xi1
+言 yan2 yan4 yin2
+訂 ding4
+訃 fu4
+訄 qiu2
+訅 qiu2
+訆 jiao4
+訇 hong1 jun4 heng1
+計 ji4
+訉 fan4
+訊 xun4
+訋 diao4
+訌 hong2 hong4
+訍 cha4
+討 tao3
+訏 xu1 xu3
+訐 jie2 ji4
+訑 yi2 dan4
+訒 ren4
+訓 xun4
+訔 yin2
+訕 shan4
+訖 qi4
+託 tuo1
+記 ji4
+訙 xun4
+訚 yin2
+訛 e2
+訜 fen1
+訝 ya4
+訞 yao1
+訟 song4 rong2
+訠 shen3
+訡 yin2 yin3 jin4
+訢 xin1 xi1 yin2
+訣 jue2
+訤 xiao2 na2
+訥 ne4 na4
+訦 chen2 shen2
+訧 you2
+訨 zhi3
+訩 xiong1
+訪 fang3
+訫 xin4
+訬 chao1 miao3
+設 she4
+訮 xian1
+訯 sha3
+訰 tun2
+許 xu3 hu3
+訲 yi4
+訳 yi4
+訴 su4
+訵 chi1
+訶 he1
+訷 shen1
+訸 he2
+訹 xu4
+診 zhen3
+註 zhu4
+証 zheng4
+訽 gou4
+訾 zi3 zi1 ci1
+訿 zi3 zi1
+詀 zhan1 che4
+詁 gu3
+詂 fu4
+詃 quan3
+詄 die2
+詅 ling2
+詆 di3 ti4
+詇 yang4
+詈 li4
+詉 nao2
+詊 pan4
+詋 zhou4
+詌 gan4
+詍 yi4
+詎 ju4
+詏 ao4
+詐 zha4
+詑 tuo2
+詒 yi2 dai4 tai2
+詓 qu3
+詔 zhao4 zhao1
+評 ping2
+詖 bi4
+詗 xiong4
+詘 qu1 chu4 qu4
+詙 ba2
+詚 da2
+詛 zu3
+詜 tao1
+詝 zhu3
+詞 ci2
+詟 zhe2
+詠 yong3
+詡 xu3
+詢 xun2
+詣 yi4
+詤 huang3
+詥 he2
+試 shi4
+詧 cha2
+詨 jiao1
+詩 shi1
+詪 hen3
+詫 cha4 du4
+詬 gou4 hou4
+詭 gui3
+詮 quan2
+詯 hui4
+詰 jie2
+話 hua4
+該 gai1
+詳 xiang2 yang2
+詴 wei1
+詵 shen1
+詶 chou2 zhou4
+詷 tong2
+詸 mi2
+詹 zhan1 shan4 dan4
+詺 ming4
+詻 e4 luo4
+詼 hui1
+詽 yan2
+詾 xiong1
+詿 gua4
+誀 er4
+誁 beng3
+誂 tiao3 diao4
+誃 chi3 chi2 yi2
+誄 lei3
+誅 zhu1
+誆 kuang1 kuang2 kuang4
+誇 kua1
+誈 wu2
+誉 yu4
+誊 teng2
+誋 ji4
+誌 zhi4
+認 ren4
+誎 su4
+誏 lang3
+誐 e2
+誑 kuang2 kuang4
+誒 e4 ai1 ei1 ei2 ei3 ei4 xi1 yi4
+誓 shi4
+誔 ting3
+誕 dan4
+誖 bo2 bei4
+誗 chan2
+誘 you4
+誙 heng2 keng1
+誚 qiao4
+誛 qin1
+誜 shua4
+誝 an1
+語 yu3 yu4
+誟 xiao4
+誠 cheng2
+誡 jie4
+誢 xian4
+誣 wu1 wu2
+誤 wu4
+誥 gao4
+誦 song4
+誧 pu3 bu1
+誨 hui4
+誩 jing4
+說 shuo1 shui4 yue4 tuo1
+誫 zhen4
+説 shuo1 shui4 yue4 tuo1
+読 du2
+誯 chang4
+誰 shui2 shei2
+誱 jie2
+課 ke4
+誳 qu1
+誴 cong2
+誵 xiao2
+誶 sui4
+誷 wang3
+誸 xuan2
+誹 fei3
+誺 chi1
+誻 ta4
+誼 yi4 yi2
+誽 na2
+誾 yin2
+調 diao4 tiao4 tiao2 zhou1
+諀 pi3
+諁 chuo4
+諂 chan3
+諃 chen1
+諄 zhun1 zhun4
+諅 ji1
+諆 qi1 ji1
+談 tan2
+諈 zhui4
+諉 wei3
+諊 ju2
+請 qing3 qing4 qing1 qing2
+諌 jian4 dong3
+諍 zheng1 zheng4
+諎 ze2
+諏 zou1 zhou1
+諐 qian1
+諑 zhuo2
+諒 liang4 liang2
+諓 jian4
+諔 zhu4
+諕 hao2 xia4
+論 lun4 lun2
+諗 shen3 nie4
+諘 biao3
+諙 huai4
+諚 pian2
+諛 yu2
+諜 die2 xie4
+諝 xu3
+諞 pian3 pian2
+諟 shi4
+諠 xuan1 xuan3
+諡 shi4
+諢 hun4
+諣 hua4
+諤 e4
+諥 zhong4
+諦 di4 ti2
+諧 xie2
+諨 fu2
+諩 pu3
+諪 ting2
+諫 jian4
+諬 qi3
+諭 yu4 tou3
+諮 zi1
+諯 chuan2
+諰 xi3
+諱 hui4
+諲 yin1
+諳 an1 tou3
+諴 xian2
+諵 nan2
+諶 chen2 shen2
+諷 feng3 feng1 feng4
+諸 zhu1 chu2
+諹 yang2
+諺 yan4
+諻 heng1
+諼 xuan1
+諽 ge2
+諾 nuo4
+諿 qi4
+謀 mou2
+謁 ye4
+謂 wei4
+謄 teng2
+謅 zou1 zhou1 chao3 chou1
+謆 shan4
+謇 jian3
+謈 bo2
+謊 huang3
+謋 huo4
+謌 ge1
+謍 ying2 hong1
+謎 mi2 mei4 mi4
+謏 xiao3
+謐 mi4
+謑 xi4 xi3
+謒 qiang1
+謓 chen1
+謔 nue4 xue4
+謕 ti2
+謖 su4
+謗 bang4
+謘 chi2
+謙 qian1 qian4 zhan4
+謚 shi4 yi4 xi4
+講 jiang3
+謜 yuan4 quan2
+謝 xie4
+謞 xue4 xiao4
+謟 tao1
+謠 yao2
+謡 yao2
+謣 yu2
+謤 biao1
+謥 cong4
+謦 qing4 qing3
+謧 li2
+謨 mo2
+謩 mo4 mo2
+謪 shang1
+謫 zhe2 ze2
+謬 miu4
+謭 jian3
+謮 ze2
+謯 jie1 zha1 zha3 zu3
+謰 lian2
+謱 lou2 lv3
+謲 can1
+謳 ou1 xu2
+謴 guan4
+謵 xi2
+謶 zhuo2
+謷 ao2 ao4
+謸 ao2 ao4
+謹 jin3
+謺 zhe2
+謻 yi2 chi2
+謼 hu4 hu1
+謽 jiang4
+謾 man2 man4
+謿 chao2 zhao1
+譀 han4
+譁 hua2
+譂 chan3
+譃 xu1
+譄 zeng1
+譅 se4
+譆 xi1
+譇 she1
+譈 dui4
+證 zheng4
+譊 nao2
+譋 lan2
+譌 e2
+譍 ying4 ying2
+譎 jue2
+譏 ji1
+譐 zun3
+譑 jiao3
+譒 bo4
+譓 hui4
+譔 zhuan4
+譕 mu2
+譖 zen4 jian4
+譗 zha2
+識 shi5 shi4 shi2 zhi4
+譙 qiao2 qiao4
+譚 tan2
+譛 zen4
+譜 pu3
+譝 sheng2
+譞 xuan1
+譟 zao4
+譠 tan1
+譡 dang3
+譢 sui4
+譣 qian1
+譤 ji1
+譥 jiao4
+警 jing3
+譧 lian2
+譨 nou2 nong2
+譩 yi1
+譪 ai4
+譫 zhan1
+譬 pi4
+譭 hui3
+譮 hua4
+譯 yi4
+議 yi4
+譱 shan4
+譲 rang4
+譳 nou4
+譴 qian3
+譵 zhui4
+譶 ta4
+護 hu4
+譸 zhou1
+譹 hao2 xia4
+譺 ye4
+譻 ying1
+譼 jian4 jian1 kan4
+譽 yu4
+譾 jian3
+譿 hui4
+讀 du2 dou4
+讁 zhe2
+讂 xuan4
+讃 zan4
+讄 lei3
+讅 shen3
+讆 wei4
+讇 chan3
+讈 li4
+讉 yi2
+變 bian4
+讋 zhe2 she4
+讌 yan4
+讍 e4
+讎 chou2
+讏 wei4
+讐 chou2
+讑 yao4
+讒 chan2
+讓 rang4
+讔 yin3
+讕 lan2
+讖 chen4 chan4
+讗 huo4
+讘 zhe2
+讙 huan1 xuan1
+讚 zan4
+讛 yi4
+讜 dang3 dang4
+讝 zhan1
+讞 yan4
+讟 du2
+讠 yan2
+计 ji4
+订 ding4
+讣 fu4
+认 ren4
+讥 ji1
+讦 jie2
+讧 hong2 hong4
+讨 tao3
+让 rang4
+讪 shan4
+讫 qi4
+讬 tuo1
+训 xun4
+议 yi4
+讯 xun4
+记 ji4
+讱 ren4
+讲 jiang3
+讳 hui4
+讴 ou1
+讵 ju4
+讶 ya4
+讷 ne4 na4
+许 xu3 hu3
+讹 e2
+论 lun4 lun2
+讻 xiong1
+讼 song4 rong2
+讽 feng1 feng3 feng4
+设 she4
+访 fang3
+诀 jue2
+证 zheng4
+诂 gu3
+诃 he1
+评 ping2
+诅 zu3
+识 shi4 shi2 zhi4
+诇 xiong4
+诈 zha4
+诉 su4
+诊 zhen3
+诋 di3
+诌 zou1 zhou1
+词 ci2
+诎 qu4 qu1
+诏 zhao4
+诐 bi4
+译 yi4
+诒 yi2
+诓 kuang1 kuang2 kuang4
+诔 lei3
+试 shi4
+诖 gua4
+诗 shi1
+诘 jie2
+诙 hui1
+诚 cheng2
+诛 zhu1
+诜 shen1
+话 hua4
+诞 dan4
+诟 gou4
+诠 quan2
+诡 gui3
+询 xun2
+诣 yi4
+诤 zheng1 zheng4
+该 gai1
+详 xiang2 yang2
+诧 cha4
+诨 hun4
+诩 xu3
+诪 zhou1
+诫 jie4
+诬 wu2 wu1
+语 yu3 yu4
+诮 qiao4
+误 wu4
+诰 gao4
+诱 you4
+诲 hui4
+诳 kuang2 kuang4
+说 shuo1 shui4 tuo1 yue4
+诵 song4
+诶 ai1 ei1 ei2 ei3 ei4 xi1
+请 qing3 qing4 qing1 qing2
+诸 zhu1
+诹 zou1
+诺 nuo4
+读 du2 dou4
+诼 zhuo2
+诽 fei3
+课 ke4
+诿 wei3
+谀 yu2
+谁 shui2 shei2
+谂 shen3
+调 diao4 tiao4 tiao2 zhou1
+谄 chan3
+谅 liang4 liang2
+谆 zhun1 zhun4
+谇 sui4
+谈 tan2
+谉 shen3
+谊 yi2 yi4
+谋 mou2
+谌 chen2
+谍 die2
+谎 huang3
+谏 jian4
+谐 xie2
+谑 nue4 xue4
+谒 ye4
+谓 wei4
+谔 e4
+谕 yu4
+谖 xuan1
+谗 chan2
+谘 zi1
+谙 an1
+谚 yan4
+谛 di4 ti2
+谜 mi2 mei4 mi4
+谝 pian2 pian3
+谞 xu3
+谟 mo2
+谠 dang3
+谡 su4
+谢 xie4
+谣 yao2
+谤 bang4
+谥 shi4
+谦 qian1 qian4
+谧 mi4
+谨 jin3
+谩 man2 man4
+谪 zhe2
+谫 jian3
+谬 miu4
+谭 tan2
+谮 zen4 jian4
+谯 qiao2 qiao4
+谰 lan2
+谱 pu3
+谲 jue2
+谳 yan4
+谴 qian3
+谵 zhan1
+谶 chen4
+谷 gu3 yu4 lu4
+谸 qian1
+谹 hong2
+谺 xia1
+谻 jue2
+谼 hong2
+谽 han1
+谾 hong1
+谿 xi1 qi1
+豀 xi1 xi2
+豁 huo1 huo4 hua2
+豂 liao2
+豃 han3
+豄 du2
+豅 long2
+豆 dou4
+豇 jiang1
+豈 qi3 kai3
+豉 chi3 shi4
+豊 li3 feng1
+豋 deng1
+豌 wan1
+豍 bi1
+豎 shu4
+豏 xian4
+豐 feng1
+豑 zhi4
+豒 zhi4
+豓 yan4
+豔 yan4
+豕 shi3
+豖 chu4
+豗 hui1
+豘 tun2
+豙 yi4
+豚 tun2 dun1
+豛 yi4
+豜 jian1
+豝 ba1
+豞 hou4
+豟 e4
+豠 cu2
+象 xiang4
+豢 huan4
+豣 jian1 yan4
+豤 ken3
+豥 gai1
+豦 qu2
+豧 fu1
+豨 xi1
+豩 bin1
+豪 hao2
+豫 yu4 xu4
+豬 zhu1
+豭 jia1
+豮 fen2
+豯 xi1
+豰 bo2 hu4 huo4 gou4
+豱 wen1
+豲 huan2 yuan2
+豳 bin1
+豴 di2
+豵 zong1
+豶 fen2
+豷 yi4
+豸 zhi4
+豹 bao4
+豺 chai2
+豻 an4 han4
+豼 pi2
+豽 na4
+豾 pi1
+豿 gou3
+貀 na4
+貁 you4
+貂 diao1
+貃 mo4
+貄 si4
+貅 xiu1
+貆 huan2 huan1
+貇 kun1
+貈 he2 hao2 ma4 mo4
+貉 he2 hao2 mo4 ma4
+貊 mo4
+貋 han4
+貌 mao4
+貍 li2 mai2
+貎 ni2
+貏 bi3
+貐 yu3
+貑 jia1
+貒 tuan1
+貓 mao1
+貔 pi2
+貕 xi1
+貖 e4
+貗 ju4
+貘 mo4
+貙 chu1
+貚 tan2
+貛 huan1
+貜 jue2
+貝 bei4
+貞 zhen1
+貟 yuan2 yun2
+負 fu4
+財 cai2
+貢 gong4
+貣 te4
+貤 yi2 yi4
+貥 hang2
+貦 wan4
+貧 pin2
+貨 huo4
+販 fan4
+貪 tan1
+貫 guan4 wan1
+責 ze2 zhai4
+貭 zhi2
+貮 er4
+貯 zhu3 zhu4
+貰 shi4
+貱 bi4
+貲 zi1
+貳 er4
+貴 gui4
+貵 pian3
+貶 bian3
+買 mai3
+貸 dai4 te4
+貹 sheng4
+貺 kuang4
+費 fei4 bi4
+貼 tie1
+貽 yi2
+貾 chi2
+貿 mao4
+賀 he4
+賁 bi4 ben1 fei2 fen2 fen4
+賂 lu4
+賃 lin4 ren4
+賄 hui4
+賅 gai1
+賆 pian2
+資 zi1 zi4
+賈 jia3 jia4 gu3
+賉 xu4
+賊 zei2 ze2
+賋 jiao3
+賌 gai4 gai1
+賍 zang1
+賎 jian4
+賏 ying4
+賐 xun4
+賑 zhen4
+賒 she1 sha1
+賓 bin1 bin4
+賔 bin1 bin4
+賕 qiu2
+賖 she1
+賗 chuan4
+賘 zang1
+賙 zhou1
+賚 lai4
+賛 zan4
+賜 ci4 si4
+賝 chen1
+賞 shang3
+賟 tian3
+賠 pei2
+賡 geng1
+賢 xian2
+賣 mai4
+賤 jian4
+賥 sui4
+賦 fu4
+賧 tan4 tan3
+賨 cong2
+賩 cong2
+質 zhi4 zhi2
+賫 ji1 qi2
+賬 zhang4
+賭 du3
+賮 jin4
+賯 xiong1 min2
+賰 shun3
+賱 yun3
+賲 bao3
+賳 zai1
+賴 lai4
+賵 feng4
+賶 cang4
+賷 ji1 qi2
+賸 sheng4
+賹 ai4
+賺 zhuan4 zuan4
+賻 fu4
+購 gou4
+賽 sai4
+賾 ze2
+賿 liao2
+贀 wei4
+贁 bai4
+贂 chen3
+贃 zhuan4 zuan4
+贄 zhi4 zhi2
+贅 zhui4
+贆 biao1
+贇 yun1
+贈 zeng4
+贉 tan3 dan3 dan4
+贊 zan4
+贋 yan4
+贍 shan4 dan4
+贎 wan4
+贏 ying2
+贐 jin4
+贑 gan3 gan4 gong4
+贒 xian2
+贓 zang1
+贔 bi4
+贕 du2
+贖 shu2 shu4
+贗 yan4
+贙 xuan4
+贚 long4
+贛 gan4 gong4 zhuang4
+贜 zang1
+贝 bei4
+贞 zhen1
+负 fu4
+贠 yuan2 yun2
+贡 gong4
+财 cai2
+责 ze2 zhai4
+贤 xian2
+败 bai4
+账 zhang4
+货 huo4
+质 zhi2 zhi4
+贩 fan4
+贪 tan1
+贫 pin2
+贬 bian3
+购 gou4
+贮 zhu3 zhu4
+贯 guan4 wan1
+贰 er4
+贱 jian4
+贲 bi4 ben1 fei2 fen2 fen4
+贳 shi4
+贴 tie1
+贵 gui4
+贶 kuang4
+贷 dai4 te4
+贸 mao4
+费 fei4 bi4
+贺 he4
+贻 yi2
+贼 zei2 ze2
+贽 zhi4
+贾 jia3 gu3 jia4
+贿 hui4
+赀 zi1
+赁 lin4 ren4
+赂 lu4
+赃 zang1
+资 zi1
+赅 gai1
+赆 jin4
+赇 qiu2
+赈 zhen4
+赉 lai4
+赊 she1 sha1
+赋 fu4
+赌 du3
+赍 ji1 qi2
+赎 shu2
+赏 shang3
+赐 ci4 si4
+赑 bi4
+赒 zhou1
+赓 geng1
+赔 pei2
+赕 tan4 tan3
+赖 lai4
+赗 feng4
+赘 zhui4
+赙 fu4
+赚 zhuan4
+赛 sai4
+赜 ze2
+赝 yan4
+赞 zan4
+赟 yun1
+赠 zeng4
+赡 shan4 dan4
+赢 ying2
+赣 gan4 gong4
+赤 chi4
+赥 xi4
+赦 she4 ce4
+赧 nan3
+赨 xiong2 tong2
+赩 xi4
+赪 cheng1
+赫 he4 xi4 shi4
+赬 cheng1
+赭 zhe3
+赮 xia2
+赯 tang2
+走 zou3
+赱 zou3
+赲 li4
+赳 jiu3 jiu1 jiu4
+赴 fu4
+赵 zhao4 tiao3
+赶 gan3 qian2
+起 qi3
+赸 shan4
+赹 qiong2
+赺 qin2
+赻 xian3
+赼 ci1
+赽 jue2
+赾 qin3
+赿 chi2 di4
+趀 ci1
+趁 chen4 zhen1 chen2
+趂 chen4
+趃 die2
+趄 ju1 qie4
+超 chao1 chao3 chao4 tiao4
+趆 di1
+趇 se4
+趈 zhan1
+趉 zhu2
+越 yue4 huo2
+趋 qu1 cu4
+趌 jie2
+趍 chi2 qu1
+趎 chu2
+趏 gua1
+趐 xue4
+趑 ci1 zi1 ci4
+趒 tiao2
+趓 duo3
+趔 lie4
+趕 gan3
+趖 suo1
+趗 cu4
+趘 xi2
+趙 zhao4 tiao3 diao4
+趚 su4
+趛 yin3
+趜 ju2
+趝 jian4
+趞 que4
+趟 tang4 cheng1 tang1 zheng1 zheng4
+趠 chuo4 chao4
+趡 cui3
+趢 lu4
+趣 qu4 cu4 qu1 cou3 zou1
+趤 dang4
+趥 qiu1
+趦 zi1
+趧 ti2
+趨 qu1 cu4 qu4 cou3
+趩 chi4
+趪 huang2
+趫 qiao2
+趬 qiao2 qiao1
+趭 yao4 jiao4
+趮 zao4
+趯 ti4 yue4
+趱 zan3
+趲 zan3 zan4 zu1
+足 zu2 ju4
+趴 pa1
+趵 bao4 zhi1 bo1 zhuo2 pao2
+趶 ku4
+趷 ke1
+趸 dun3
+趹 jue2 gui4
+趺 fu1
+趻 chen3
+趼 jian3 yan4
+趽 fang4
+趾 zhi3
+趿 sa4 ta1 qi4
+跀 yue4
+跁 pa2
+跂 qi2 qi3 qi4
+跃 yue4
+跄 qiang1 qiang4
+跅 tuo4
+跆 tai2
+跇 yi4
+跈 nian3 jian4
+跉 ling2
+跊 mei4
+跋 ba2 bei4
+跌 die1 die2 tu2
+跍 ku1
+跎 tuo2
+跏 jia1
+跐 ci3 cai3
+跑 pao3 pao2 bo2
+跒 qia3
+跓 zhu4
+跔 ju1
+跕 die2 tie1
+跖 zhi2 zhi1
+跗 fu1
+跘 pan2
+跙 ju3
+跚 shan1
+跛 bo3 bi4 po1
+跜 ni2
+距 ju4
+跞 li4 luo4
+跟 gen1
+跠 yi2
+跡 ji1 ji4
+跢 dai4
+跣 xian3 xian1 sun3
+跤 jiao1 qiao1
+跥 duo4
+跦 zhu1
+跧 quan2 zun1 zhuan1
+跨 kua4 ku4 kua1 kua3
+跩 zhuai3 shi4
+跪 gui4
+跫 qiong2 qiong1 qiang1
+跬 kui3 xie4
+跭 xiang2
+跮 chi4 die2
+路 lu4 luo4
+跰 beng4 pian2
+跱 zhi4 shi4
+跲 jia2
+跳 tiao4 tiao2 tao2 diao4
+跴 cai3
+践 jian4
+跶 ta4 da5
+跷 qiao1
+跸 bi4
+跹 xian1
+跺 duo4
+跻 ji1
+跼 ju2
+跽 ji4
+跾 shu2
+跿 tu2
+踀 chu4
+踁 jing4
+踂 nie4
+踃 xiao1
+踄 bo2
+踅 chi4 xue2
+踆 qun1 cun1 cun2
+踇 mou3
+踈 shu1
+踉 lang2 liang2 liang4 lang4
+踊 yong3
+踋 jiao3 jue2
+踌 chou2
+踍 qiao1
+踏 ta4 ta1
+踐 jian4
+踑 qi2 ji1
+踒 wo1
+踓 wei3
+踔 zhuo2 chuo1 diao4 zhuo1 tiao4
+踕 jie2
+踖 ji2
+踗 nie1
+踘 ju2 ju1
+踙 ju1
+踚 lun2
+踛 lu4
+踜 leng4
+踝 huai2 hua4
+踞 ju4
+踟 chi2
+踠 wan3
+踡 quan2
+踢 ti1 die2
+踣 bo2 pou4
+踤 zu2 cui4
+踥 qie4
+踦 ji3 ji1 qi1 yi3
+踧 cu4 di2
+踨 zong1
+踩 cai3 kui2
+踪 zong1
+踫 peng4
+踬 zhi4
+踭 zheng1
+踮 dian3
+踯 zhi2
+踰 yu2
+踱 duo4 duo2 chuo4
+踲 dun4
+踳 chun3
+踴 yong3
+踵 zhong3 zhong4
+踶 di4 chi2 ti2 zhi4
+踷 zhe3
+踸 chen3
+踹 chuai4 shuan4 duan4
+踺 jian4
+踻 gua1
+踼 tang2
+踽 ju3
+踾 fu2
+踿 zu2
+蹀 die2
+蹁 pian2
+蹂 rou2
+蹃 nuo4
+蹄 ti2 di4
+蹅 cha3
+蹆 tui3
+蹇 jian3 qian1
+蹈 dao3 dao4
+蹉 cuo1 chuai4
+蹊 xi1 qi1 xi2
+蹋 ta4
+蹌 qiang1 qiang4
+蹍 zhan3 nian3
+蹎 dian1
+蹏 ti2 di4
+蹐 ji2
+蹑 nie4
+蹒 pan2 man2
+蹓 liu1 liu4
+蹔 zhan4 zan4
+蹕 bi4
+蹖 chong1
+蹗 lu4
+蹘 liao2
+蹙 cu4
+蹚 tang1
+蹛 dai4 zhi4
+蹜 suo1 su4
+蹝 xi3
+蹞 kui3
+蹟 ji1 ji4
+蹠 zhi2
+蹡 qiang1 qiang4
+蹢 di2 zhi2
+蹣 pan2 man2 liang3
+蹤 zong1
+蹥 lian2
+蹦 beng4
+蹧 zao1
+蹨 nian3
+蹩 bie2
+蹪 tui2
+蹫 ju2
+蹬 deng4 deng1
+蹭 ceng4 ceng2
+蹮 xian1
+蹯 fan2 fan1
+蹰 chu2
+蹱 zhong1
+蹲 dun1 dun2 cun2 zun1 cun3 cuan2
+蹳 bo1
+蹴 cu4 zu2
+蹵 zu2 cu4
+蹶 jue2 jue3 gui4
+蹷 jue2
+蹸 lin4
+蹹 ta4
+蹺 qiao1 qiao4
+蹻 qiao1 jue2
+蹼 pu2 pu3
+蹽 liao1
+蹾 dun1
+蹿 cuan1
+躀 kuang4
+躁 zao4
+躂 ta4 da5
+躃 bi4
+躄 bi4
+躅 zhu2 zhuo2
+躆 ju4
+躇 chu2 chuo4
+躈 qiao4
+躉 dun3
+躊 chou2
+躋 ji1
+躌 wu3
+躍 yue4 ti4
+躎 nian3
+躏 lin4
+躐 lie4
+躑 zhi2
+躒 li4 luo4 yue4
+躓 zhi4 zhi1
+躔 chan2 zhan4
+躕 chu2
+躖 duan4
+躗 wei4
+躘 long2
+躙 lin4
+躚 xian1
+躛 wei4
+躜 zuan1
+躝 lan2
+躞 xie4
+躟 rang2
+躠 xie3 sa3 xie4
+躡 nie4
+躢 ta4
+躣 qu2
+躤 jie4 ji2
+躥 cuan1
+躦 zuan1 cuo2
+躧 xi3
+躨 kui2
+躩 jue2
+躪 lin4
+身 shen1 yuan2 juan1
+躬 gong1
+躭 dan1
+躯 qu1
+躰 ti3
+躱 duo3
+躲 duo3
+躳 gong1
+躴 lang2
+躶 luo3
+躷 ai3
+躸 ji1
+躹 ju2
+躺 tang3
+躽 yan3
+躿 kang1
+軀 qu1
+軁 lou2
+軂 lao4
+軃 tuo3 duo3
+軄 zhi2
+軆 ti3
+軇 dao4
+軉 yu4
+車 che1 ju1
+軋 ya4 ga2 zha2
+軌 gui3
+軍 jun1
+軎 wei4
+軏 yue4
+軐 xin4 xian4
+軑 di4 dai4
+軒 xuan1 xian3 xian4 han3 jian1
+軓 fan4
+軔 ren4
+軕 shan1
+軖 qiang2
+軗 shu1
+軘 tun2
+軙 chen2 qi2
+軚 dai4
+軛 e4
+軜 na4
+軝 qi2
+軞 mao2
+軟 ruan3
+軠 ren4
+軡 fan3
+転 zhuan3
+軣 hong1
+軤 hu1
+軥 qu2 gou1 ju1
+軦 huang4
+軧 di3
+軨 ling2
+軩 dai4
+軪 ao1
+軫 zhen3
+軬 fan4 ben4
+軭 kuang1
+軮 ang3 yang3
+軯 peng1
+軰 bei4
+軱 gu1
+軲 ku1
+軳 pao2
+軴 zhu4
+軵 rong3 fu3
+軶 e4
+軷 ba2
+軸 zhou2 zhu2 zhou4
+軹 zhi3
+軺 yao2 diao1
+軻 ke1
+軼 yi4 die2 zhe2
+軽 qing1
+軾 shi4
+軿 ping2 peng1
+輀 er2
+輁 qiong2 gong3
+輂 ju2
+較 jiao4 jue2 xiao4
+輄 guang1
+輅 lu4 ya4 he2
+輆 kai3
+輇 quan2 chun1
+輈 zhou1
+載 zai4 zai3 dai4 zai1 zi1
+輊 zhi4
+輋 she1
+輌 liang4
+輍 yu4
+輎 shao1
+輏 you2
+輐 huan3 wan4
+輑 yun3
+輒 zhe2
+輓 wan3
+輔 fu3
+輕 qing1 qing4
+輖 zhou1
+輗 ni2
+輘 ling2 leng2
+輙 zhe2
+輚 zhan4
+輛 liang4
+輜 zi1 zi4
+輝 hui1
+輞 wang3
+輟 chuo4
+輠 guo3 guo1 hua4 hui4
+輡 kan3
+輢 yi3
+輣 peng2
+輤 qian4
+輥 gun3
+輦 nian3
+輧 pian2 ping2
+輨 guan3
+輩 bei4
+輪 lun2
+輫 pai2 pei2
+輬 liang2
+輭 ruan3
+輮 rou2 rou3
+輯 ji2
+輰 yang2
+輱 xian2
+輲 chuan2
+輳 cou4
+輴 chun1 shun1 qun1
+輵 ge2
+輶 you2
+輷 hong1
+輸 shu1 shu4
+輹 fu4
+輺 zi1 zi4
+輻 fu2
+輼 wen1
+輽 ben4
+輾 zhan3 nian3
+輿 yu2 yu4
+轀 wen1
+轁 tao1 kan3
+轂 gu3 gu1
+轃 zhen1
+轄 xia2 he2
+轅 yuan2
+轆 lu4
+轇 jiu1 jiao1
+轈 chao2
+轉 zhuan3 zhuan4
+轊 wei4
+轋 hun2
+轍 che4 zhe2
+轎 jiao4
+轏 zhan4
+轐 pu2 bu2
+轑 lao3 lao2 liao3
+轒 fen2
+轓 fan1
+轔 lin2 lin4
+轕 ge2
+轖 se4
+轗 kan3
+轘 huan4 huan2
+轙 yi3
+轚 ji2
+轛 dui4
+轜 er2
+轝 yu2
+轞 xian4
+轟 hong1
+轠 lei3 lei2
+轡 pei4
+轢 li4
+轣 li4
+轤 lu2
+轥 lin4
+车 che1 ju1
+轧 ya4 ga2 zha2
+轨 gui3
+轩 xuan1
+轪 di4 dai4
+轫 ren4
+转 zhuan3 zhuan4
+轭 e4
+轮 lun2
+软 ruan3
+轰 hong1
+轱 ku1
+轲 ke1
+轳 lu2
+轴 zhou2 zhu2
+轵 zhi3
+轶 yi4 die2
+轷 hu1
+轸 zhen3
+轹 li4
+轺 yao2
+轻 qing1
+轼 shi4
+载 zai4 zai3
+轾 zhi4
+轿 jiao4
+辀 zhou1
+辁 quan2
+辂 lu4 ya4
+较 jiao4 jue2
+辄 zhe2
+辅 fu3
+辆 liang4
+辇 nian3
+辈 bei4
+辉 hui1
+辊 gun3
+辋 wang3
+辌 liang2
+辍 chuo4
+辎 zi1
+辏 cou4
+辐 fu2
+辑 ji2
+辒 wen1
+输 shu1
+辔 pei4
+辕 yuan2
+辖 xia2
+辗 zhan3 nian3
+辘 lu4
+辙 zhe2 che4
+辚 lin2 lin4
+辛 xin1
+辜 gu1
+辝 ci2
+辞 ci2
+辟 pi4 pi1 bi4 mi3
+辠 zui4
+辡 bian4
+辢 la4
+辣 la4
+辤 ci2
+辥 xue1
+辦 ban4
+辧 bian4
+辨 bian4 ban1 ban4 bian3 pian4
+辩 bian4 pian2
+辫 bian4
+辬 ban1
+辭 ci2
+辮 bian4
+辯 bian4 pian2 bian3 ban4
+辰 chen2
+辱 ru3 ru4
+農 nong2
+辳 nong2
+辴 zhen3
+辵 chuo4
+辶 chuo4
+辸 reng2
+边 bian1 bian5
+辺 bian1
+辽 liao2
+达 da2 ti4 ta4
+辿 chan1
+迀 gan1
+迁 qian1 gan1
+迂 yu1 yu4
+迃 yu1
+迄 qi4
+迅 xun4
+迆 yi3 yi2
+过 guo4 guo1
+迈 mai4
+迉 qi2
+迊 za1
+迋 wang4 guang3 guang4 kuang2
+迍 zhun1 tun2
+迎 ying2 ying4
+迏 ti4
+运 yun4
+近 jin4 ji4
+迒 hang2
+迓 ya4
+返 fan3
+迕 wu4 wu3
+迖 da2 ti4 ta4
+迗 e2
+还 huan2 hai2 xuan2
+这 zhe4 zhei4
+进 jin4
+远 yuan3 yuan4
+违 wei2
+连 lian2
+迟 chi2 zhi2
+迠 che4
+迡 ni4
+迢 tiao2
+迣 zhi4 chi4 li4
+迤 yi3 tuo1 yi2 tuo2
+迥 jiong3
+迦 jia1 xie4
+迧 chen2 zhen4
+迨 dai4
+迩 er3
+迪 di2
+迫 po4 pai3
+迬 wang3
+迭 die2
+迮 ze2 zuo4
+迯 tao2
+述 shu4
+迱 tuo2
+迳 jing4
+迴 hui2
+迵 tong2
+迶 you4
+迷 mi2 mei4 mi4
+迸 beng4 bing3 peng1
+迹 ji1 ji4
+迺 nai3
+迻 yi2
+迼 jie2
+追 zhui1 dui1 tui1
+迾 lie4
+迿 xun4
+退 tui4
+送 song4
+适 shi4 gua1 kuo4
+逃 tao2
+逄 pang2 feng2
+逅 hou4 gou4
+逆 ni4
+逇 dun4
+逈 jiong3
+选 xuan3 suan4
+逊 xun4
+逋 bu1
+逌 you2
+逍 xiao1
+逎 qiu2
+透 tou4 shu1
+逐 zhu2 di2 zhou4 tun2
+逑 qiu2
+递 di4 dai4
+逓 di4
+途 tu2
+逕 jing4
+逖 ti4
+逗 dou4 zhu4 tou2 qi2
+逘 yi3
+這 zhe4 zhei4 yan4
+通 tong1 tong4
+逛 guang4 kuang2
+逜 wu4
+逝 shi4
+逞 cheng3 ying2
+速 su4
+造 zao4 cao4 cao1
+逡 qun1 jun4 xun4 suo1
+逢 feng2 pang2 peng2
+連 lian2 lian3 lian4 lan4
+逤 suo4
+逥 hui2
+逦 li3
+逨 lai2
+逩 ben4 ben1
+逪 cuo4
+逫 jue2
+逬 beng4
+逭 huan4
+逮 dai4 dai3 di4
+逯 lu4 dai4
+逰 you2
+週 zhou1
+進 jin4
+逳 yu4
+逴 chuo4
+逵 kui2
+逶 wei1
+逷 ti4
+逸 yi4
+逹 da2
+逺 yuan3 yuan4
+逻 luo2 luo4
+逼 bi1
+逽 nuo4
+逾 yu2 dou4
+逿 dang4 tang2
+遀 sui2
+遁 dun4 xun2 qun1
+遂 sui4 sui2
+遃 yan3
+遄 chuan2
+遅 chi2
+遆 ti2
+遇 yu4
+遈 shi2
+遉 zhen1 zheng1
+遊 you2
+運 yun4
+遌 e4
+遍 bian4
+過 guo4 guo5 guo1 huo4
+遏 e4
+遐 xia2
+遑 huang2
+遒 qiu2 qiu1
+道 dao4 dao3
+達 da2 ta4 ti4
+違 wei2 hui2
+遗 yi2 wei4
+遘 gou4
+遙 yao2
+遚 chu4
+遛 liu2 liu4
+遜 xun4
+遝 ta4 dai4
+遞 di4 dai4
+遟 chi2 zhi4 xi1
+遠 yuan3 yuan4
+遡 su4
+遢 ta4
+遣 qian3 qian4
+遥 yao2
+遦 guan4
+遧 zhang1
+遨 ao2
+適 shi4 di2 ti4 zhe2
+遪 ce4
+遫 chi4
+遬 su4
+遭 zao1
+遮 zhe1
+遯 dun4
+遰 di4 shi4
+遱 lou2
+遲 chi2 zhi4 xi1 zhi2
+遳 cuo1
+遴 lin2 lin4
+遵 zun1
+遶 rao4 rao3
+遷 qian1
+選 xuan3 suan4 xuan4
+遹 yu4
+遺 yi2 wei4 sui2
+遻 wu4 e4
+遼 liao2
+遽 ju4 qu2
+遾 shi4
+避 bi4
+邀 yao1
+邁 mai4
+邂 xie4
+邃 sui4
+還 huan2 hai2 xuan2
+邅 zhan1
+邆 teng2
+邇 er3
+邈 miao3 miao2
+邉 bian1
+邊 bian1
+邋 la2 la1 lie4
+邌 li2
+邍 yuan2
+邎 yao2
+邏 luo2 luo4
+邐 li3
+邑 yi4 e4
+邒 ting2
+邓 deng4
+邔 qi3 ji4
+邕 yong1 yong3
+邖 shan1
+邗 han2
+邘 yu2
+邙 mang2
+邚 ru2
+邛 qiong2
+邝 kuang4
+邞 fu1
+邟 kang4 kang2
+邠 bin1
+邡 fang1 fang3 fang4
+邢 xing2 geng3
+那 na4 nei4 na1 na3 ne2 nei3 nuo2 nuo4
+邥 shen3
+邦 bang1
+邧 yuan2
+邨 cun1
+邩 huo3
+邪 xie2 xu2 ya2 ye2 yu2 she2
+邫 bang1
+邬 wu1
+邭 ju4
+邮 you2
+邯 han2 han4
+邰 tai2
+邱 qiu1
+邲 bi4
+邳 pei2 pi1
+邴 bing3
+邵 shao4
+邶 bei4
+邷 wa3
+邸 di3
+邹 zou1
+邺 ye4
+邻 lin2
+邼 kuang1
+邽 gui1
+邾 zhu1
+邿 shi1
+郀 ku1
+郁 yu4
+郂 gai1
+郃 he2 xia2 ge2
+郄 xi4 que4
+郅 zhi4 zhi1 ji2
+郆 ji2
+郇 xun2 huan2
+郈 hou4
+郉 xing2
+郊 jiao1
+郋 xi2 xi1
+郌 gui1
+郍 nuo2
+郎 lang2 lang4
+郏 jia2
+郐 kuai4
+郑 zheng4
+郓 yun4
+郔 yan2
+郕 cheng2
+郖 dou1 dou4
+郗 chi1 xi1
+郘 lv3
+郙 fu3
+郚 wu2
+郛 fu2
+郜 gao4
+郝 hao3 shi4
+郞 lang2 lang4
+郟 jia2
+郠 geng3
+郡 jun4
+郢 ying3 cheng2
+郣 bo2
+郤 xi4
+郥 bei4
+郦 li4 zhi2
+郧 yun2
+部 bu4 pou3
+郩 xiao2
+郪 qi1 ci1
+郫 pi2
+郬 qing1
+郭 guo1 guo2
+郯 tan2
+郰 zou1
+郱 ping2
+郲 lai2
+郳 ni2
+郴 chen1 lan2
+郵 you2 chui2
+郶 bu4
+郷 xiang1
+郸 dan1
+郹 ju2
+郺 yong1
+郻 qiao1
+郼 yi1
+都 du1 dou1
+郾 yan3 yan1
+郿 mei2 fei2
+鄀 ruo4
+鄁 bei4
+鄂 e4
+鄃 yu2 shu1
+鄄 juan4
+鄅 yu3
+鄆 yun4
+鄇 hou4
+鄈 kui2
+鄉 xiang1 xiang3 xiang4
+鄊 xiang1
+鄋 sou1
+鄌 tang2
+鄍 ming2
+鄎 xi4
+鄏 ru4 ru3
+鄐 chu4
+鄑 zi1
+鄒 zou1 ju4
+鄓 ju2
+鄔 wu1
+鄕 xiang1 xiang3 xiang4
+鄖 yun2
+鄗 hao4
+鄘 yong1 yong2
+鄙 bi3
+鄚 mo4
+鄛 chao2
+鄜 fu1
+鄝 liao3
+鄞 yin2
+鄟 zhuan1
+鄠 hu4
+鄡 qiao1
+鄢 yan1
+鄣 zhang1 zhang4
+鄤 man4 wan4 fan4
+鄥 qiao1
+鄦 xu3
+鄧 deng4
+鄨 bi4
+鄩 xin2 xun2
+鄪 bi4
+鄫 ceng2 zeng1
+鄬 wei2
+鄭 zheng4
+鄮 mao4
+鄯 shan4
+鄰 lin2 lin4
+鄱 po2 pi2 pan2
+鄲 dan1 duo1
+鄳 meng2
+鄴 ye4
+鄵 cao1 cao4
+鄶 kuai4
+鄷 feng1
+鄸 meng2
+鄹 zou1 ju4
+鄺 kuang4 kuo4
+鄻 lian3 lian2
+鄼 zan4 cuo2
+鄽 chan2
+鄾 you1
+鄿 qi2
+酀 yan1
+酁 chan2
+酂 zan4 da2
+酃 ling2
+酄 huan1
+酅 xi1
+酆 feng1
+酇 zan4 da2
+酈 li4 zhi2 li2
+酉 you3
+酊 ding3 ding1
+酋 qiu2
+酌 zhuo2
+配 pei4
+酎 zhou4
+酏 yi2 hu4 tuo2 yi3
+酐 hang4 gan1 hang3 han2
+酑 yu3
+酒 jiu3
+酓 yan3
+酔 zui4
+酕 mao2
+酖 dan1 zhen4
+酗 xu4
+酘 tou2
+酙 zhen1
+酚 fen1
+酝 yun4
+酞 tai4
+酟 tian1
+酠 qia3
+酡 tuo2
+酢 zuo4 cu4
+酣 han1 han4
+酤 gu1
+酥 su1
+酦 po4 po1
+酧 chou2
+酨 zai4 zui4
+酩 ming2 ming3
+酪 lao4 luo4 lu4
+酫 chuo4
+酬 chou2
+酭 you4
+酮 tong2 dong4 chong2
+酯 zhi3
+酰 xian1
+酱 jiang4
+酲 cheng2
+酳 yin4
+酴 tu2
+酵 jiao4 xiao4
+酶 mei2
+酷 ku4
+酸 suan1
+酹 lei4
+酺 pu2
+酻 zui4
+酼 hai3
+酽 yan4
+酾 xi3 li2 shai1 shi1
+酿 niang4 niang2
+醀 wei2
+醁 lu4
+醂 lan3
+醃 yan1
+醄 tao2
+醅 pei1
+醆 zhan3
+醇 chun2
+醈 tan2
+醉 zui4
+醊 chuo4 zhui1
+醋 cu4
+醌 kun1
+醍 ti2 ti3
+醎 mian2
+醏 du1
+醐 hu2
+醑 xu3
+醒 xing3 xing1 cheng2 jing1
+醓 tan3
+醔 jiu1
+醕 chun2
+醖 yun4
+醗 po4
+醘 ke4
+醙 sou1
+醚 mi2
+醛 quan2 chuo4
+醜 chou3
+醝 cuo2 cuo1
+醞 yun4
+醟 yong4 yong3
+醠 ang4
+醡 zha4
+醢 hai3
+醣 tang2
+醤 jiang4
+醥 piao3
+醦 shan3
+醧 yu4
+醨 li2
+醩 zao2 zao1
+醪 lao2
+醫 yi1
+醬 jiang4
+醭 bu2 pu1 pu2
+醮 jiao4 qiao2 zhan4
+醯 xi1
+醰 tan2
+醱 po4 po1
+醲 nong2
+醳 yi4 shi4
+醴 li3
+醵 ju4
+醶 jiao4
+醷 yi4
+醸 niang4
+醹 ru2
+醺 xun1
+醻 chou2
+醼 yan4
+醽 ling2
+醾 mi2
+醿 mi2
+釀 niang4 niang2
+釁 xin4
+釂 jiao4
+釃 xi3 li2 shai1 shi1
+釄 mi2
+釅 yan4
+釆 bian4 cai3
+采 cai3 cai4
+釈 shi4
+釉 you4
+释 shi4 yi4
+釋 shi4 yi4
+里 li3
+重 zhong4 chong2 tong2
+野 ye3
+量 liang4 liang2
+釐 li2 xi1
+金 jin1 jin4
+釓 ga2 qiu2
+釔 yi3
+釕 liao3 liao4 diao3
+釖 dao1
+釗 zhao1
+釘 ding1 ding4 ling2
+釙 po4 po1
+釚 qiu2
+釛 he2
+釜 fu3
+針 zhen1
+釞 zhi2
+釟 ba1
+釠 luan4
+釡 fu3
+釢 nai2
+釣 diao4
+釤 shan4 shan1 xian1
+釥 qiao3
+釦 kou4
+釧 chuan4
+釨 zi3
+釩 fan2 fan3 fan4
+釪 yu2
+釫 hua2
+釬 han4 gan1
+釭 gang1 gong1
+釮 qi2
+釯 mang2
+釰 ri4
+釱 di4 dai4
+釲 si4
+釳 xi4
+釴 yi4
+釵 chai1 cha1
+釶 shi1 she2
+釷 tu3
+釸 xi4
+釹 nv3
+釺 qian1
+釼 jian4
+釽 pi1 pi4
+釾 ye2
+釿 yin2 jin1
+鈀 ba3 pa2 ba1
+鈁 fang1
+鈂 chen2
+鈃 xing2 jian1
+鈄 dou3
+鈅 yue4
+鈆 yan2 qian1
+鈇 fu1 fu3
+鈈 pi1 bu4
+鈉 na4 rui4
+鈊 xin1
+鈋 e2
+鈌 jue2
+鈍 dun4
+鈎 gou1
+鈏 yin3
+鈐 qian2 han2
+鈑 ban3
+鈒 ji2 sa4
+鈓 ren2
+鈔 chao1 miao3 chao3
+鈕 niu3 chou3
+鈖 fen1
+鈗 yun3
+鈘 ji3
+鈙 qin2
+鈚 pi2 pi1
+鈛 guo1
+鈜 hong2
+鈝 yin2
+鈞 jun1
+鈟 shi1
+鈠 yi4
+鈡 zhong1
+鈢 nie1
+鈣 gai4
+鈤 ri4
+鈥 huo3 huo2
+鈦 tai4
+鈧 kang4
+鈬 duo2
+鈭 zi1
+鈮 ni2 ni3
+鈯 tu2
+鈰 shi4
+鈱 min2
+鈲 gu1
+鈳 ke1 e1
+鈴 ling2
+鈵 bing4
+鈶 yi2
+鈷 gu3 gu1 gu2 gu4 hu2
+鈸 bo2 ba2
+鈹 pi1 pi2
+鈺 yu4
+鈻 si4
+鈼 zuo2
+鈽 bu4 bu1
+鈾 you2 zhou4
+鈿 dian4 tian2
+鉀 jia3 he2 ge2
+鉁 zhen1
+鉂 shi3
+鉃 shi4
+鉄 tie3
+鉅 ju4
+鉆 chan1 qian2 tie1 zhan1 qin2
+鉇 shi1 yi2 she2
+鉈 shi1 she2 yi2 tuo2 ta1
+鉉 xuan4
+鉊 zhao1
+鉋 bao4 pao2
+鉌 he2
+鉍 bi4 se4
+鉎 sheng1
+鉏 chu2 ju3 xu2
+鉐 shi2
+鉑 bo2
+鉒 zhu4
+鉓 chi4
+鉔 za1
+鉕 po1 po3
+鉖 tong2
+鉗 qian2 an1
+鉘 fu2
+鉙 zhai3
+鉚 mao3 liu3
+鉛 qian1 yan2
+鉜 fu2
+鉝 li4
+鉞 yue4 hui4
+鉟 pi1
+鉠 yang1
+鉡 ban4
+鉢 bo1
+鉣 jie2
+鉤 gou1 gou4 qu2
+鉥 shu4
+鉦 zheng1
+鉧 mu3
+鉨 ni3 nie3 xi3
+鉩 nie1 xi3
+鉪 di4
+鉫 jia1
+鉬 mu4
+鉭 dan4 tan3
+鉮 shen1 shen2
+鉯 yi3
+鉰 si1
+鉱 kuang4
+鉲 ka3
+鉳 bei3
+鉴 jian4
+鉵 tong2
+鉶 xing2
+鉷 hong2
+鉸 jiao3
+鉹 chi3
+鉺 er3 er4 keng1
+鉻 ge4 ge2 luo4 ge1
+鉼 bing3
+鉽 shi4
+鉾 mou2
+鉿 ha1 jia1 ge1 ke1 jia2
+銀 yin2
+銁 jun1
+銂 zhou1
+銃 chong4
+銄 shang4
+銅 tong2
+銆 mo4
+銇 lei4
+銈 ji1
+銉 yu4
+銊 xu4
+銋 ren2
+銌 zun4
+銍 zhi4
+銎 qiong1 qiong2
+銏 shan4
+銐 chi4
+銑 xian3 xi3 xian1
+銒 xing2 jian1
+銓 quan2
+銔 pi1
+銕 tie3 yi2
+銖 zhu1
+銗 hou2 hou4 xiang4
+銘 ming2
+銙 kua3
+銚 yao2 diao4 tiao2 qiao1 yao4
+銛 xian1
+銜 xian2
+銝 xiu1
+銞 jun1
+銟 cha1
+銠 lao3
+銡 ji2
+銢 pi3
+銣 ru2 ru3
+銤 mi3
+銥 yi1 yi3
+銦 yin1
+銧 guang1
+銨 an3 an1
+銩 diu1
+銪 you3
+銫 se4
+銬 kao4
+銭 qian2
+銮 luan2
+銰 ai1
+銱 diao4
+銲 han4
+銳 rui4 dui4 yue4
+銴 shi4
+銵 keng1
+銶 qiu2
+銷 xiao1
+銸 zhe2
+銹 xiu4
+銺 zang4
+銻 ti1 ti2 ti4
+銼 cuo4
+銽 gua1
+銾 gong3
+銿 zhong1 yong1
+鋀 dou4
+鋁 lv3 lv4
+鋂 mei2
+鋃 lang2
+鋄 wan3 wan4
+鋅 xin1 zi3
+鋆 yun2
+鋇 bei4
+鋈 wu4
+鋉 su4
+鋊 yu4
+鋋 chan2 yan2
+鋌 ting3 ding4
+鋍 bo2
+鋎 han4
+鋏 jia2
+鋐 hong2
+鋑 cuan1
+鋒 feng1
+鋓 chan1
+鋔 wan3
+鋕 zhi4
+鋖 si1
+鋗 xuan1 juan1
+鋘 wu2 hua2
+鋙 wu2 yu3
+鋚 tiao2
+鋛 gong3
+鋜 zhuo2
+鋝 lve4
+鋞 xing2
+鋟 qian1 qin3 qin1 jin4
+鋠 shen4
+鋡 han2
+鋢 lve4
+鋣 xie2 ye2
+鋤 chu2 ju3
+鋥 zheng4 zeng4
+鋦 ju1 ju2
+鋧 xian4
+鋨 tie3 e2
+鋩 mang2
+鋪 pu1 pu4
+鋫 li2
+鋬 pan4
+鋭 rui4 dui4
+鋮 cheng2
+鋯 gao4
+鋰 li3
+鋱 te4
+鋳 zhu4
+鋵 tu1
+鋶 liu3
+鋷 zui4
+鋸 ju4 ju1
+鋹 chang3
+鋺 yuan1
+鋻 jian4
+鋼 gang1 gang4
+鋽 diao4
+鋾 tao2
+鋿 chang2
+錀 lun2
+錁 guo3 kua3 ke4
+錂 ling2
+錃 bei1
+錄 lu4
+錅 li2
+錆 qiang1
+錇 pou2 pei2 fu2
+錈 juan4
+錉 min2
+錊 zui4
+錋 peng2 beng4
+錌 an4
+錍 pi2 pi1
+錎 xian4
+錏 ya4
+錐 zhui1
+錑 lei4
+錒 a1 ke1
+錓 kong1
+錔 ta4
+錕 kun1 gun3
+錖 du3
+錗 wei4
+錘 chui2
+錙 zi1
+錚 zheng1
+錛 ben1
+錜 nie1 nie4
+錝 cong2
+錞 dui4 chun2 duo4 qun2
+錟 tan2 xian1 yan3
+錠 ding4
+錡 qi2 yi3
+錢 qian2 jian3
+錣 zhuo2 zhui4
+錤 qi2 ji1
+錥 yu4
+錦 jin3
+錧 guan3
+錨 mao2
+錩 chang1
+錪 tian3
+錫 xi2 xi1 ti4
+錬 lian4
+錭 tao2 diao1
+錮 gu4
+錯 cuo4 cu4 xi1
+錰 shu4
+錱 zhen1
+録 lu4 lv4
+錳 meng3
+錴 lu4
+錵 hua1
+錶 biao3
+錷 ga2
+錸 lai2
+錹 ken3
+錼 nai4
+錽 wan3 wan4
+錾 zan4
+鍀 de2
+鍁 xian1
+鍃 huo1 huo4
+鍄 liang4
+鍆 men2
+鍇 kai3 jie1 jie3
+鍈 ying1
+鍉 di1 chi2 di2 shi2
+鍊 lian4
+鍋 guo1 guo3
+鍌 xian3
+鍍 du4
+鍎 tu2
+鍏 wei2
+鍐 cong1
+鍑 fu4
+鍒 rou2
+鍓 ji2
+鍔 e4
+鍕 rou2
+鍖 chen3 zhen1
+鍗 ti2
+鍘 zha2
+鍙 hong4
+鍚 yang2
+鍛 duan4
+鍜 xia1 xia2
+鍝 yu2
+鍞 keng1
+鍟 xing1
+鍠 huang2
+鍡 wei3
+鍢 fu4
+鍣 zhao1
+鍤 cha2 cha1
+鍥 qie4
+鍦 she2 shi1
+鍧 hong1
+鍨 kui2
+鍩 tian3 nuo4
+鍪 mou2
+鍫 qiao1
+鍬 qiao1
+鍭 hou2
+鍮 tou1
+鍯 cong1
+鍰 huan2
+鍱 ye4
+鍲 min2
+鍳 jian4
+鍴 duan1
+鍵 jian4
+鍶 si1 song1
+鍷 kui1
+鍸 hu2
+鍹 xuan1
+鍺 zhe3 duo3 du3
+鍻 jie2
+鍼 zhen1 qian2
+鍽 bian1
+鍾 zhong1
+鍿 zi1
+鎀 xiu1
+鎁 ye2
+鎂 mei3
+鎃 pai4
+鎄 ai1
+鎅 jie4
+鎇 mei2
+鎈 chuo1
+鎉 ta4
+鎊 bang4 pang1
+鎋 xia2
+鎌 lian2
+鎍 suo3
+鎎 xi4
+鎏 liu2
+鎐 zu2 yao2
+鎑 ye4
+鎒 nou4
+鎓 weng1
+鎔 rong2
+鎕 tang2
+鎖 suo3
+鎗 qiang1 qiang4 cheng1
+鎘 ge2 li4
+鎙 shuo4
+鎚 chui2
+鎛 bo2
+鎜 pan2
+鎝 sa4 da1
+鎞 bi4 bi1 pi1
+鎟 sang3
+鎠 gang1
+鎡 zi1
+鎢 wu1 wu4
+鎣 ying4 ying2 jiong3
+鎤 huang3
+鎥 tiao2
+鎦 liu2 liu4
+鎧 kai3
+鎨 sun3
+鎩 sha1 shi4 se4
+鎪 sou1
+鎫 wan4 jian3
+鎬 hao4 gao3
+鎭 zhen4 zhen1 tian2
+鎮 zhen4 zhen1 tian2
+鎯 luo3 lang2
+鎰 yi4
+鎱 yuan2
+鎲 tang3
+鎳 nie4
+鎴 xi2
+鎵 jia1
+鎶 ge1
+鎷 ma3
+鎸 juan1
+鎻 suo3
+鎿 na2
+鏀 lu3
+鏁 suo3
+鏂 ou1 kou1
+鏃 zu2 chuo4
+鏄 tuan2
+鏅 xiu1
+鏆 guan4
+鏇 xuan4 xuan2
+鏈 lian4 lian2
+鏉 shou4
+鏊 ao2 ao4
+鏋 man3
+鏌 mo4
+鏍 luo2
+鏎 bi4
+鏏 wei4
+鏐 liu2
+鏑 di2 di1
+鏒 qiao1
+鏓 cong1 song3
+鏔 yi2
+鏕 lu4
+鏖 ao2 biao1
+鏗 keng1
+鏘 qiang1
+鏙 cui1
+鏚 qi4 qi1
+鏛 chang2
+鏜 tang1 tang2
+鏝 man4
+鏞 yong1
+鏟 chan3
+鏠 feng1
+鏡 jing4
+鏢 biao1
+鏣 shu4
+鏤 lou4 lv2
+鏥 xiu4
+鏦 cong1
+鏧 long2
+鏨 zan4 jian4
+鏩 jian4
+鏪 cao2
+鏫 li2
+鏬 xia4
+鏭 xi1
+鏮 kang1
+鏰 beng4
+鏳 zheng1
+鏴 lu4
+鏵 hua2
+鏶 ji2
+鏷 pu2
+鏸 hui4
+鏹 qiang1 qiang3
+鏺 po1
+鏻 lin2
+鏼 suo3
+鏽 xiu4
+鏾 san3 xian4
+鏿 cheng1
+鐀 kui4 gui4
+鐁 si1
+鐂 liu4 liu2
+鐃 nao2 nao4
+鐄 heng2
+鐅 pie3
+鐆 sui4
+鐇 fan2
+鐈 qiao2
+鐉 quan1
+鐊 yang2
+鐋 tang4 tang1
+鐌 xiang4
+鐍 jue2
+鐎 jiao1
+鐏 zun1
+鐐 liao2 liao4
+鐑 jie2
+鐒 lao2
+鐓 dui4 dui1 dun1
+鐔 tan2 xin1 xin2
+鐕 zan1
+鐖 ji1
+鐗 jian3
+鐘 zhong1
+鐙 deng4 deng1
+鐚 ya4
+鐛 ying4
+鐜 dui4
+鐝 jue2
+鐞 nou4
+鐟 ti4
+鐠 pu3
+鐡 tie3
+鐤 ding3 zhen1
+鐥 shan4
+鐦 kai1
+鐧 jian3 jian4 jian1
+鐨 fei4
+鐩 sui4
+鐪 lu3
+鐫 juan1
+鐬 hui4
+鐭 yu4
+鐮 lian2
+鐯 zhuo2 zhuo1
+鐰 qiao1
+鐱 qian1
+鐲 zhuo2 shu3
+鐳 lei2
+鐴 bi4
+鐵 tie3 die2
+鐶 huan2
+鐷 ye4
+鐸 duo2
+鐹 guo3
+鐺 dang1 cheng1 tang1
+鐻 ju4 qu2
+鐼 fen2 ben1
+鐽 da2
+鐾 bei4 bi4
+鐿 yi4
+鑀 ai4
+鑁 zong1
+鑂 xun4
+鑃 diao4
+鑄 zhu4
+鑅 heng2
+鑆 zhui4
+鑇 ji1
+鑈 nie1
+鑉 ta4
+鑊 huo4
+鑋 qing4 qing1
+鑌 bin1
+鑍 ying1
+鑎 kui4
+鑏 ning2
+鑐 xu1 ru2
+鑑 jian4
+鑒 jian4
+鑔 cha3
+鑕 zhi4
+鑖 mie4 mi4
+鑗 li2
+鑘 lei2
+鑙 ji1
+鑚 zuan4 zuan1
+鑛 kuang4
+鑜 shang4
+鑝 peng2
+鑞 la4
+鑟 du2
+鑠 shuo4 yue4 li4
+鑡 chuo4
+鑢 lv4
+鑣 biao1
+鑤 bao4 pao2
+鑥 lu3
+鑨 long2
+鑩 e4
+鑪 lu2
+鑫 xin1 xun4
+鑬 jian4
+鑭 lan2 lan4
+鑮 bo2
+鑯 jian1
+鑰 yao4 yue4
+鑱 chan2
+鑲 xiang1 rang2
+鑳 jian4
+鑴 xi1 hui1
+鑵 guan4
+鑶 cang2
+鑷 nie4
+鑸 lei3
+鑹 cuan4 cuan1
+鑺 qu2
+鑻 pan4
+鑼 luo2
+鑽 zuan1 zuan4
+鑾 luan2
+鑿 zao2 zuo4 zu2 zao4
+钀 nie4
+钁 jue2
+钂 tang3
+钃 shu3 zhu2
+钄 lan2
+钅 jin1
+钆 qiu2 ga2
+钇 yi3
+针 zhen1
+钉 ding1 ding4
+钊 zhao1
+钋 po4
+钌 diao3 liao3
+钍 tu3
+钎 qian1
+钏 chuan4
+钐 shan4 shan1 xian1
+钑 ji2 sa4
+钒 fan2
+钓 diao4
+钔 men2
+钕 nv3
+钖 xi2 xi1
+钗 chai1
+钘 xing2 jian1
+钙 gai4
+钚 bu4
+钛 tai4
+钜 ju4
+钝 dun4
+钞 chao1 miao3
+钟 zhong1
+钠 na4
+钡 bei4
+钢 gang1 gang4
+钣 ban3
+钤 qian2
+钥 yao4 yue4
+钦 qin1
+钧 jun1
+钨 wu4 wu1
+钩 gou1
+钪 kang4
+钫 fang1
+钬 huo2 huo3
+钭 dou3
+钮 niu3
+钯 ba3 pa2
+钰 yu4
+钱 qian2 jian3
+钲 zheng1
+钳 qian2
+钴 gu1 gu2 gu3
+钵 bo1
+钶 e1 ke1
+钷 po1 po3
+钸 bu4
+钹 ba2 bo2
+钺 yue4 hui4
+钻 zuan4 zuan1
+钼 mu4
+钽 dan4 tan3
+钾 jia3 he2
+钿 dian4 tian2
+铀 you2
+铁 tie3
+铂 bo2
+铃 ling2
+铄 shuo4
+铅 qian1 yan2
+铆 mao3 liu3
+铇 bao4
+铈 shi4
+铉 xuan4
+铊 ta1 she2 shi1 tuo2
+铋 bi4
+铌 ni3
+铍 pi1 pi2
+铎 duo2
+铏 xing2
+铐 kao4
+铑 lao3
+铒 er4
+铓 mang2
+铔 ya4
+铕 you3
+铖 cheng2
+铗 jia2
+铘 ye2
+铙 nao2
+铚 zhi4
+铛 dang1 cheng1
+铜 tong2
+铝 lv3
+铞 diao4
+铟 yin1
+铠 kai3
+铡 zha2
+铢 zhu1
+铣 xian3 xi3
+铤 ting3
+铥 diu1
+铦 xian1
+铧 hua2
+铨 quan2
+铩 sha1
+铪 jia2 ha1 jia1 ke1
+铫 yao2 tiao2
+铬 ge4 ge2 luo4
+铭 ming2
+铮 zheng1
+铯 se4
+铰 jiao3
+铱 yi3 yi1
+铲 chan3
+铳 chong4
+铴 tang4
+铵 an1
+银 yin2
+铷 ru3 ru2
+铸 zhu4
+铹 lao2
+铺 pu1 pu4
+铻 wu2 yu3
+铼 lai2
+铽 te4
+链 lian4
+铿 keng1
+销 xiao1
+锁 suo3
+锂 li3
+锃 zheng4 zeng4
+锄 chu2
+锅 guo1
+锆 gao4
+锇 tie3 e2
+锈 xiu4
+锉 cuo4
+锊 lve4
+锋 feng1
+锌 xin1
+锍 liu3
+锎 kai1
+锏 jian3 jian4
+锐 rui4 dui4 yue4
+锑 ti4 ti1
+锒 lang2
+锓 qian1 qin3
+锔 ju2 ju1
+锕 a1
+锖 qiang1
+锗 duo3 zhe3
+锘 tian3 nuo4
+错 cuo4 cu4
+锚 mao2
+锛 ben1
+锜 qi2 yi3
+锝 de2
+锞 kua3 ke4
+锟 kun1
+锠 chang1
+锡 xi2 ti4
+锢 gu4
+锣 luo2
+锤 chui2
+锥 zhui1
+锦 jin3
+锧 zhi4
+锨 xian1
+锩 juan4
+锪 huo1 huo4
+锫 pou2 pei2
+锬 tan2 xian1
+锭 ding4
+键 jian4
+锯 ju4 ju1
+锰 meng3
+锱 zi1
+锲 qie4
+锳 ying1
+锴 kai3 jie1
+锵 qiang1
+锶 song1 si1
+锷 e4
+锸 cha2
+锹 qiao1
+锺 zhong1
+锻 duan4
+锼 sou1
+锽 huang2
+锾 huan2
+锿 ai1
+镀 du4
+镁 mei3
+镂 lou4
+镃 zi1
+镄 fei4
+镅 mei2
+镆 mo4
+镇 zhen4
+镈 bo2
+镉 ge2 li4
+镊 nie4
+镋 tang3
+镌 juan1
+镍 nie4
+镎 na2
+镏 liu2 liu4
+镐 hao4 gao3
+镑 bang4
+镒 yi4
+镓 jia1
+镔 bin1
+镕 rong2
+镖 biao1
+镗 tang1
+镘 man4
+镙 luo2
+镚 beng4
+镛 yong1
+镜 jing4
+镝 di2 di1
+镞 zu2
+镟 xuan4
+镠 liu2
+镡 tan2 xin2
+镢 jue2
+镣 liao2 liao4
+镤 pu2
+镥 lu3
+镦 dui4
+镧 lan4 lan2
+镨 pu3
+镩 cuan4 cuan1
+镪 qiang1 qiang3
+镫 deng1 deng4
+镬 huo4
+镭 lei2
+镮 huan2
+镯 zhuo2
+镰 lian2
+镱 yi4
+镲 cha3
+镳 biao1
+镴 la4
+镵 chan2
+镶 xiang1 rang2
+長 chang2 zhang3 zhang4
+镸 chang2
+镹 jiu3
+镺 ao3 ao4
+镻 die2
+镼 qu1 jue2
+镽 liao3
+镾 mi2
+长 chang2 zhang3 zhang4
+門 men2
+閁 ma4
+閂 shuan1
+閃 shan3
+閄 huo4
+閅 men2
+閆 yan2 yan3 yan4
+閇 bi4
+閈 han4
+閉 bi4
+開 kai1
+閌 kang4 kang1
+閍 beng1
+閎 hong2
+閏 run4
+閐 san4
+閑 xian2
+閒 xian2 jian1 jian4
+間 jian1 jian4 jian3
+閔 min3 min2
+閕 xia1 xia4
+閗 dou4
+閘 zha2 ya1 ge2
+閙 nao4
+閛 peng1
+閜 xia3 xia4 ke3
+閝 ling2
+閞 bian4
+閟 bi4
+閠 run4
+閡 he2 gai1 ai4 hai4 kai3
+関 guan1 wan1 wan3
+閣 ge2
+閤 ge2 he2
+閥 fa2
+閦 chu4
+閧 hong4 hong3
+閨 gui1
+閩 min3
+閫 kun3
+閬 lang3 du1
+閭 lv2
+閮 ting2
+閯 sha4
+閰 ju2
+閱 yue4
+閲 yue4
+閳 chan3
+閴 qu4
+閵 lin4
+閶 chang1 tang1
+閷 shai4 sha1
+閸 kun3
+閹 yan1
+閺 wen2 min2
+閻 yan2 yan4 yan3
+閼 e4 yan1 yu4 ye4
+閽 hun1
+閾 yu4
+閿 wen2
+闀 xiang4
+闁 bao1
+闂 xiang4
+闃 qu4
+闄 yao3
+闅 wen2
+闆 ban3
+闇 an4 an1 yan3
+闈 wei2
+闉 yin1
+闊 kuo4
+闋 que4 jue2 kui2
+闌 lan2 lan4
+闍 du1 she2
+闐 tian2
+闑 nie4
+闒 ta4
+闓 kai3 kai1
+闔 he2 ge2
+闕 que4 que1 jue2
+闖 chuang3 chen4
+闗 guan1
+闘 dou4
+闙 qi3
+闚 kui1 kui3
+闛 tang2 chang1 tang1
+關 guan1
+闝 piao2
+闞 kan4 han3 xian4
+闟 xi4 ta4 sa4
+闠 hui4
+闡 chan3
+闢 pi4
+闣 dang4
+闤 huan2
+闥 ta4
+闦 wen2
+门 men2
+闩 shuan1
+闪 shan3
+闫 yan4
+闬 han4
+闭 bi4
+问 wen4
+闯 chuang3 chen4
+闰 run4
+闱 wei2
+闲 xian2
+闳 hong2
+间 jian1 jian4
+闵 min3
+闶 kang4 kang1
+闷 men4 men1
+闸 zha2
+闹 nao4
+闺 gui1
+闻 wen2 wen4
+闼 ta4
+闽 min3
+闾 lv2
+闿 kai3 kai1
+阀 fa2
+阁 ge2
+阂 he2 gai1
+阃 kun3
+阄 jiu1
+阅 yue4
+阆 lang3 lang4 lang2 liang3
+阇 du1 she2
+阈 yu4
+阉 yan1
+阊 chang1
+阋 xi4
+阌 wen2
+阍 hun1
+阎 yan2 yan4
+阏 e4 yan1 yu4
+阐 chan3
+阑 lan2
+阒 qu4
+阓 hui4
+阔 kuo4
+阕 que4
+阖 ge2 he2
+阗 tian2
+阘 ta4
+阙 que4 jue2 que1
+阚 kan4
+阛 huan2
+阜 fu4
+阝 fu4 yi4
+阞 le4
+队 dui4 sui4 zhui4
+阠 xin4
+阡 qian1
+阢 wu4 wei4
+阣 yi4
+阤 tuo2 yi3 zhi4
+阥 yin1 yin4 an1
+阦 yang2
+阧 dou3
+阨 e4 ai4
+阩 sheng1
+阪 ban3
+阫 pei2 pei1
+阬 keng1 gang1
+阭 yun3
+阮 ruan3 juan4 yuan2
+阯 zhi3
+阰 pi2
+阱 jing3
+防 fang2
+阳 yang2
+阴 yin1 yin4 an1
+阵 zhen4
+阶 jie1
+阷 cheng1
+阸 e4 ai4
+阹 qu1
+阺 di3
+阻 zu3 zhu4
+阼 zuo4
+阽 dian4 yan2
+阾 ling3
+阿 a1 a4 a5 e1 e3 a3
+陀 tuo2 duo4
+陁 tuo2 yi3
+陂 bei1 bi4 po1 pi2
+陃 bing3
+附 fu4 pou3 bu4 fu1
+际 ji4
+陆 lu4 liu4
+陇 long3
+陈 chen2 zhen4
+陉 xing2 jing4
+陊 duo4
+陋 lou4
+陌 mo4
+降 jiang4 xiang2 xiang4
+陎 shu1
+陏 duo4
+限 xian4 wen3
+陑 er2
+陒 gui3
+陓 yu1 wu1
+陔 gai1
+陕 shan3
+陖 xun4 jun4
+陗 qiao4
+陘 xing2 jing4
+陙 chun2
+陚 fu4
+陛 bi4
+陜 xia2 shan3
+陝 shan3
+陞 sheng1
+陟 zhi4 de2
+陠 pu1
+陡 dou3
+院 yuan4
+陣 zhen4
+除 chu2 zhu4 shu1
+陥 xian4
+陧 nie4
+陨 yun3 yuan2
+险 xian3 yan2
+陪 pei2
+陫 pei2 fei3
+陬 zou1 zhe2
+陭 yi1 qi1 yi4
+陮 dui3
+陯 lun2
+陰 yin1 yin4 an1
+陱 ju1
+陲 chui2
+陳 chen2 zhen4
+陴 pi2 bi4
+陵 ling2
+陶 tao2 dao4 yao2
+陷 xian4
+陸 lu4 liu4
+険 xian3
+陻 yin1
+陼 zhu3 du3
+陽 yang2
+陾 reng2
+陿 shan3 xia2
+隀 chong2
+隁 yan4
+隂 yin1 an1 yin4
+隃 yu2 yao2
+隄 di1 ti2
+隅 yu2
+隆 long2 long1
+隇 wei1
+隈 wei1
+隉 nie4
+隊 dui4 sui4 zhui4
+隋 sui2 duo4 tuo3 tuo1
+隌 an3
+隍 huang2
+階 jie1
+随 sui2
+隐 yin3 yin4
+隑 gai1 gai4 qi2
+隒 yan3
+隓 hui1
+隔 ge2 rong3 ji1
+隕 yun3 yuan2
+隖 wu4
+隗 wei3 gui1 kui2
+隘 ai4 e4
+隙 xi4
+隚 tang2
+際 ji4
+障 zhang4 zhang1
+隝 dao3
+隞 ao2
+隟 xi4
+隠 yin3
+隢 rao4
+隣 lin2
+隤 tui2
+隥 deng4
+隦 pi3
+隧 sui4 zhui4
+隨 sui2
+隩 yu4 ao4
+險 xian3 yan2 jian3
+隫 fen1 fen2
+隬 ni3
+隭 er2
+隮 ji1
+隯 dao3
+隰 xi2 xie4
+隱 yin3 yin4
+隲 e2
+隳 hui1
+隴 long3
+隵 xi1
+隶 li4 dai4 yi4 di4
+隷 li4
+隸 li4
+隹 zhui1 cui1 wei2
+隺 he4
+隻 zhi1
+隼 zhun3 sun3
+隽 jun4 juan4
+难 nan2 nan4 nuo2
+隿 yi4
+雀 que4 qiao1 qiao3
+雁 yan4
+雂 qin2 qian2
+雃 ya3
+雄 xiong2
+雅 ya3 ya1 ya2
+集 ji2
+雇 gu4
+雈 huan2
+雉 zhi4 kai3 yi3 si4
+雊 gou4
+雋 jun4 juan4
+雌 ci2 ci1
+雍 yong1
+雎 ju1
+雏 chu2
+雐 hu1
+雑 za2
+雒 luo4
+雓 yu2
+雔 chou2
+雕 diao1
+雖 sui1
+雗 han4
+雘 huo4
+雙 shuang1
+雚 guan4
+雛 chu2 ju2 ju4
+雜 za2
+雝 yong1
+雞 ji1
+雟 xi1 sui3
+雠 chou2
+雡 liu4
+離 li2 li4 li3 chi1 gu3
+難 nan2 nan4 nuo2
+雤 xue2
+雥 za2
+雦 ji2
+雧 ji2
+雨 yu3 yu4
+雩 yu2 yu4 xu1
+雪 xue3
+雫 na3
+雬 fou3
+雭 se4
+雮 mu4
+雯 wen2
+雰 fen1
+雱 pang2
+雲 yun2
+雳 li4
+雴 li4
+雵 ang3
+零 ling2 lian2
+雷 lei2 lei4
+雸 an2
+雹 bao2 bo2
+雺 meng2
+電 dian4
+雼 dang4
+雽 xing2
+雾 wu4
+雿 zhao4
+需 xu1 nuo4 ruan3 ru2
+霁 ji4
+霂 mu4
+霃 chen2
+霄 xiao1 xiao4
+霅 zha2 xia2 zha4 sha4
+霆 ting2
+震 zhen4 shen1
+霈 pei4
+霉 mei2
+霊 ling2
+霋 qi1
+霌 chou1
+霍 huo4 he4 suo3
+霎 sha4
+霏 fei1
+霐 weng1
+霑 zhan1
+霒 yin1
+霓 ni2
+霔 zhu4
+霕 tun2
+霖 lin2
+霘 dong4
+霙 ying1
+霚 wu4
+霛 ling2
+霜 shuang1
+霝 ling2 ling4
+霞 xia2
+霟 hong2
+霠 yin1
+霡 mo4 mai4
+霢 mai4
+霣 yun3
+霤 liu4
+霥 meng4
+霦 bin1
+霧 wu4 meng2
+霨 wei4
+霩 huo4 kuo4
+霪 yin2
+霫 xi2
+霬 yi4
+霭 ai3
+霮 dan4
+霯 deng4
+霰 xian4
+霱 yu4
+露 lu4 lou4
+霳 long2
+霴 dai4
+霵 ji2
+霶 pang2 pang1
+霷 yang2
+霸 ba4 po4
+霹 pi1
+霺 wei2
+霼 xi3 xi4
+霽 ji4
+霾 mai2 li2
+霿 meng4 meng2 mou4
+靀 meng2
+靁 lei2 lei4
+靂 li4
+靃 huo4 sui3
+靄 ai3
+靅 fei4
+靆 dai4
+靇 long2
+靈 ling2 ling4
+靉 ai4
+靊 feng1
+靋 li4
+靌 bao3
+靎 he4
+靏 he4
+靐 bing4
+靑 qing1
+青 qing1 jing1
+靓 liang4
+靔 tian1
+靕 zhen1
+靖 jing4 jing1
+靗 cheng4
+靘 qing4
+静 jing4
+靚 liang4 jing4
+靛 dian4
+靜 jing4
+靝 tian1
+非 fei1 fei3
+靟 fei1
+靠 kao4
+靡 mi3 mi2 ma2 mei2 mo2
+面 mian4
+靣 mian4
+靤 pao4
+靥 ye4
+靦 tian3 mian3
+靧 hui4
+靨 ye4 yan3
+革 ge2 ji2 ji3
+靪 ding1
+靫 cha1 chai1
+靬 jian1
+靭 ren4
+靮 di2
+靯 du4
+靰 wu4
+靱 ren4
+靲 qin2 jin4
+靳 jin4
+靴 xue1
+靵 niu3
+靶 ba3 ba4
+靷 yin3
+靸 sa3 ta1
+靹 na4
+靺 mo4
+靻 zu3
+靼 da2
+靽 ban4
+靾 yi4 xie4
+靿 yao4
+鞀 tao2
+鞁 tuo2 bei4
+鞂 jia2
+鞃 hong2
+鞄 pao2 bao4
+鞅 yang3 yang1
+鞇 yin1
+鞈 jia2 ge2 ta4
+鞉 tao2
+鞊 ji2
+鞋 xie2 wa1
+鞌 an1
+鞍 an1
+鞎 hen2
+鞏 gong3
+鞑 da2
+鞒 qiao1
+鞓 ting1
+鞔 wan3 man2 men4
+鞕 ying4
+鞖 sui1
+鞗 tiao2
+鞘 qiao4 shao1
+鞙 xuan4 juan1
+鞚 kong4
+鞛 beng3
+鞜 ta4
+鞝 zhang3
+鞞 bing3 bi3 pi2
+鞟 kuo4
+鞠 ju1 ju2 qu1 qiong1
+鞡 la5
+鞢 xie4
+鞣 rou2
+鞤 bang1
+鞥 yi4 eng1
+鞦 qiu1
+鞧 qiu1
+鞨 he2 mo4
+鞩 xiao4
+鞪 mu4 mou2
+鞫 ju2 ju1 qu1
+鞬 jian1 jian4
+鞭 bian1
+鞮 di1
+鞯 jian1
+鞱 tao1
+鞲 gou1
+鞳 ta4
+鞴 bei4 bu4 fu2 bai4
+鞵 xie2
+鞶 pan2
+鞷 ge2
+鞸 bi4
+鞹 kuo4
+鞻 lou2 lv3
+鞼 gui4
+鞽 qiao2
+鞾 xue1
+鞿 ji1
+韀 jian1
+韁 jiang1
+韂 chan4
+韃 da2 ta4
+韄 huo4 hu4
+韅 xian3
+韆 qian1
+韇 du2
+韈 wa4
+韉 jian1
+韊 lan2
+韋 wei2 hui2
+韌 ren4
+韍 fu2
+韎 mei4
+韏 juan4
+韐 ge2
+韑 wei3
+韒 qiao4
+韓 han2
+韔 chang4
+韖 rou2
+韗 xun4 yun4
+韘 she4
+韙 wei3
+韚 ge2
+韛 bei4
+韜 tao1 tao4
+韝 gou1
+韞 yun4 wen1
+韠 bi4
+韡 wei3
+韢 hui4
+韣 du2
+韤 wa4
+韥 du2
+韦 wei2
+韧 ren4
+韨 fu2
+韩 han2
+韪 wei3
+韫 yun4
+韬 tao1
+韭 jiu3
+韮 jiu3
+韯 xian1
+韰 xie4
+韱 xian1
+韲 ji1
+音 yin1 yin4
+韴 za2
+韵 yun4
+韶 shao2
+韷 le4
+韸 peng2
+韹 heng2
+韺 ying1
+韻 yun4
+韼 peng2
+韽 yin1 an1
+韾 yin1
+響 xiang3
+頀 hu4 huo4
+頁 ye4 xie2
+頂 ding3
+頃 qing3 kui3 qing1
+頄 kui2 qiu2 pan4
+項 xiang4
+順 shun4
+頇 han1 an4
+須 xu1
+頉 yi2
+頊 xu4
+頋 gu4
+頌 song4 rong2
+頍 kui3
+頎 qi2 ken3
+頏 hang2 gang1 hang4
+預 yu4
+頑 wan2 kun1
+頒 ban1 fen2
+頓 dun4 du2 zhun1
+頔 di2
+頕 dan1
+頖 pan4
+頗 po1 po3 po4 pi2
+領 ling3
+頙 ce4
+頚 jing3
+頛 lei3
+頜 he2 han4 ge2 han2 qin1
+頝 qiao1
+頞 e4
+頟 e2
+頠 wei3
+頡 jie2 jia2 xie2
+頢 gua1
+頣 shen3
+頤 yi2
+頥 shen3
+頦 hai2 ke1 ke2
+頧 dui1
+頨 pian1
+頩 ping1
+頪 lei4
+頫 fu3 tiao4
+頬 jia2
+頭 tou2 tou5
+頮 hui4
+頯 kui2 qiu2
+頰 jia2
+頱 le4
+頲 ting3 tian5
+頳 cheng1
+頴 ying3
+頵 jun1 yun1
+頶 hu2
+頷 han4
+頸 jing3 geng3
+頹 tui2
+頺 tui2
+頻 pin2 bin1
+頼 lai4
+頽 tui2
+頾 zi1
+頿 zi1
+顀 chui2
+顁 ding4
+顂 lai4
+顃 yan2
+顄 han4
+顅 jian1
+顆 ke1 ke3 kuan3
+顇 cui4
+顈 jiong3
+顉 qin1 han4
+顊 yi2
+顋 sai1
+題 ti2 di4
+額 e2
+顎 e4
+顏 yan2 ya2
+顐 hun2 hun4
+顑 kan3
+顒 yong2
+顓 zhuan1
+顔 yan2 ya2
+顕 xian3
+顖 xin4
+顗 yi3
+願 yuan4
+顙 sang3
+顚 dian1
+顛 dian1 tian2
+顜 jiang3 jiao4
+顝 ku1
+類 lei4 li4
+顟 liao2
+顠 piao4 piao3 piao1
+顡 yi4
+顢 man2 man1
+顣 qi1 cu4
+顤 rao4
+顥 hao4
+顦 qiao2
+顧 gu4
+顨 xun4
+顩 qian1 qin1 yan3
+顪 hui1 hui4
+顫 zhan4 chan4 shan1
+顬 ru2
+顭 hong1
+顮 bin1
+顯 xian3
+顰 pin2
+顱 lu2
+顲 lan3
+顳 nie4
+顴 quan2
+页 ye4
+顶 ding3
+顷 qing3 kui3 qing1
+顸 han1
+项 xiang4
+顺 shun4
+须 xu1
+顼 xu4
+顽 wan2
+顾 gu4
+顿 dun4 du2 zhun1
+颀 qi2 ken3
+颁 ban1 fen2
+颂 song4 rong2
+颃 hang2 gang1
+预 yu4
+颅 lu2
+领 ling3
+颇 po3 po1
+颈 jing3 geng3
+颉 jie2 jia2 xie2
+颊 jia2
+颋 tian5 ting3
+颌 han4 ge2 he2
+颍 ying3
+颎 jiong3
+颏 hai2 ke1 ke2
+颐 yi2
+频 pin2 bin1
+颒 hui4
+颓 tui2
+颔 han4
+颕 ying3
+颖 ying3
+颗 ke1 ke3 kuan3
+题 ti2 di4
+颙 yong2
+颚 e4
+颛 zhuan1
+颜 yan2
+额 e2
+颞 nie4
+颟 man2 man1
+颠 dian1 tian2
+颡 sang3
+颢 hao4
+颣 lei4
+颤 zhan4 chan4 shan1
+颥 ru2
+颦 pin2
+颧 quan2
+風 feng1 feng3 feng4
+颩 biao1 diu1
+颫 fu2
+颬 xia1
+颭 zhan3
+颮 biao1 pao2
+颯 sa4 li4
+颰 ba2
+颱 tai2
+颲 lie4
+颳 gua1
+颴 xuan4
+颵 shao4
+颶 ju4
+颷 bi1
+颸 si1
+颹 wei3
+颺 yang2
+颻 yao2
+颼 sou1
+颽 kai3
+颾 sao1
+颿 fan2 fan1 fan4
+飀 liu2
+飁 xi2
+飂 liao2 liu2 liu4
+飃 piao1
+飄 piao1
+飅 liu2
+飆 biao1
+飇 biao1
+飈 biao3 biao1
+飉 liao2
+飋 se4
+飌 feng1
+飍 biao1 xiu1
+风 feng1 feng3 feng4
+飏 yang2
+飐 zhan3
+飑 biao1
+飒 sa4
+飓 ju4
+飔 si1
+飕 sou1
+飖 yao2
+飗 liu2
+飘 piao1
+飙 biao1
+飚 biao1
+飛 fei1
+飜 fan1
+飝 fei1
+飞 fei1
+食 shi2 si4 yi4
+飠 shi2
+飡 can1 sun1
+飢 ji1
+飣 ding4
+飤 si4
+飥 tuo1
+飦 zhan1
+飧 sun1
+飨 xiang3
+飩 tun2 tun5 zhun4
+飪 ren4
+飫 yu4
+飬 juan4 yang3
+飭 chi4 shi4
+飮 yin3
+飯 fan4
+飰 fan4
+飱 sun1
+飲 yin3 yin4
+飳 zhu4
+飴 yi2 si4
+飵 zhai3 zuo4
+飶 bi4
+飷 jie3
+飸 tao1
+飹 liu3
+飺 ci2
+飻 tie4
+飼 si4
+飽 bao3
+飾 shi4 chi4
+飿 duo4
+餀 hai4
+餁 ren4
+餂 tian3
+餃 jiao3 jiao4
+餄 jia2 he2
+餅 bing3
+餆 yao2
+餇 tong2
+餈 ci2 zi1
+餉 xiang3
+養 yang3 yang4
+餋 yang3
+餌 er3
+餍 yan4
+餎 le5
+餏 yi1
+餐 can1 sun4
+餑 bo1 bo2
+餒 nei3
+餓 e4
+餔 bu1 bu3
+餕 jun4
+餖 dou4
+餗 su4
+餘 yu2 ye2
+餙 shi4
+餚 yao2
+餛 hun2 kun1
+餜 guo3
+餝 shi4
+餞 jian4
+餟 zhui4
+餠 bing3
+餡 xian4 kan4
+餢 bu4
+餣 ye4
+餤 tan2 dan4
+餥 fei3
+餦 zhang1
+餧 wei4 nei3
+館 guan3
+餩 e4
+餪 nuan3
+餫 hun2 yun4
+餬 hu2
+餭 huang2
+餮 tie4
+餯 hui4
+餰 jian1 zhan1
+餱 hou2
+餲 he2 ai4
+餳 xing2 tang2
+餴 fen1
+餵 wei4
+餶 gu3
+餷 cha1
+餸 song4
+餹 tang2
+餺 bo2
+餻 gao1
+餼 xi4
+餽 kui4
+餾 liu4 liu2
+餿 sou1
+饀 tao2
+饁 ye4
+饂 yun2
+饃 mo2
+饄 tang2
+饅 man2
+饆 bi4
+饇 yu4
+饈 xiu1
+饉 jin3
+饊 san3
+饋 kui4 tui2
+饌 zhuan4 xuan3
+饍 shan4
+饎 chi4 xi1
+饏 dan4
+饐 yi4
+饑 ji1 qi2
+饒 rao2
+饓 cheng1
+饔 yong1
+饕 tao1
+饖 hui4
+饗 xiang3
+饘 zhan1
+饙 fen1
+饚 hai4
+饛 meng2
+饜 yan4
+饝 mo2
+饞 chan2
+饟 xiang3
+饠 luo2
+饡 zuan4 zan4
+饢 nang3 nang2
+饣 shi2
+饤 ding4
+饥 ji1
+饦 tuo1
+饧 xing2
+饨 tun2 tun5
+饩 xi4
+饪 ren4
+饫 yu4
+饬 chi4
+饭 fan4
+饮 yin3 yin4
+饯 jian4
+饰 shi4
+饱 bao3
+饲 si4
+饳 duo4
+饴 yi2 si4
+饵 er3
+饶 rao2
+饷 xiang3
+饸 jia2 he2
+饹 le5
+饺 jiao3
+饻 yi1
+饼 bing3
+饽 bo2 bo1
+饾 dou4
+饿 e4
+馀 yu2
+馁 nei3
+馂 jun4
+馃 guo3
+馄 hun2
+馅 xian4
+馆 guan3
+馇 cha1
+馈 kui4
+馉 gu3
+馊 sou1
+馋 chan2
+馌 ye4
+馍 mo2
+馎 bo2
+馏 liu4 liu2
+馐 xiu1
+馑 jin3
+馒 man2
+馓 san3
+馔 zhuan4 xuan3
+馕 nang3 nang2
+首 shou3
+馗 kui2 qiu2
+馘 guo2 xu4
+香 xiang1
+馚 fen2
+馛 ba2
+馜 ni3
+馝 bi4
+馞 bo2
+馟 tu2
+馠 han1
+馡 fei1
+馢 jian1
+馣 an1
+馤 ai3
+馥 fu4 bi4
+馦 xian1
+馧 wen1
+馨 xin1 xing1
+馩 fen2
+馪 bin1
+馫 xing1
+馬 ma3
+馭 yu4
+馮 feng2 ping2
+馯 han4 han2
+馰 di4
+馱 tuo2 duo4 dai4
+馲 tuo1
+馳 chi2
+馴 xun2 xun4
+馵 zhu4
+馶 zhi1
+馷 pei4
+馸 xin4
+馹 ri4
+馺 sa4
+馻 yin3
+馼 wen2
+馽 zhi2
+馾 dan4
+馿 lv2
+駀 you2
+駁 bo2
+駂 bao3
+駃 kuai4 jue2
+駄 tuo2
+駅 yi4
+駆 qu1
+駈 qu1
+駉 jiong1
+駊 bo3 po3
+駋 zhao1
+駌 yuan1
+駍 peng1
+駎 zhou4
+駏 ju4
+駐 zhu4
+駑 nu2
+駒 ju1 ju4
+駓 pi1 pi2
+駔 zang3 zu3 zu4
+駕 jia4 jia1
+駖 ling2
+駗 zhen1
+駘 tai2 dai4 zhai4 tai1
+駙 fu4
+駚 yang3
+駛 shi3
+駜 bi4
+駝 tuo2
+駞 tuo2
+駟 si4
+駠 liu2
+駡 ma4
+駢 pian2
+駣 tao2
+駤 zhi4
+駥 rong2 xue4
+駦 teng2
+駧 dong4
+駨 xun2
+駩 quan2
+駪 shen1
+駫 jiong1
+駬 er3
+駭 hai4
+駮 bo2
+駰 yin1
+駱 luo4 jia4
+駳 dan4
+駴 xie4
+駵 liu2
+駶 ju2
+駷 song3
+駸 qin1
+駹 mang2
+駺 liang2
+駻 han4
+駼 tu2
+駽 xuan4 xuan1
+駾 tui4
+駿 jun4
+騀 e2 e3
+騁 cheng3
+騂 xing1
+騃 ai2 dai1
+騄 lu4
+騅 zhui1
+騆 zhou1
+騇 she3 she4
+騈 pian2
+騉 kun1
+騊 tao2
+騋 lai2
+騌 zong1
+騍 ke4
+騎 qi2 ji4
+騏 qi2
+騐 yan4
+騑 fei1
+騒 sao1
+験 yan3
+騔 jie2
+騕 yao3
+騖 wu4
+騗 pian4
+騘 cong1
+騙 pian4
+騚 qian2
+騛 fei1
+騜 huang2
+騝 jian1
+騞 huo4 huo1
+騟 yu4
+騠 ti2
+騡 quan2
+騢 xia2
+騣 zong1
+騤 kui2
+騥 rou2
+騦 si1
+騧 gua1
+騨 tuo2
+騩 kui4 gui1
+騪 sou1
+騫 qian1 jian3
+騬 cheng2
+騭 zhi4
+騮 liu2
+騯 pang2
+騰 teng2
+騱 xi1
+騲 cao3
+騳 du2
+騴 yan4
+騵 yuan2
+騶 zou1 zhou4 zhu1 qu1
+騷 sao1 sao3 xiao1
+騸 shan4
+騹 li2 qi2
+騺 zhi4
+騻 shuang3 shuang1
+騼 lu4
+騽 xi2
+騾 luo2
+騿 zhang1
+驀 mo4 ma4
+驁 ao4 ao2 yao4
+驂 can1
+驃 piao4 biao1
+驄 cong1
+驅 qu1
+驆 bi4
+驇 zhi4
+驈 yu4
+驉 xu1
+驊 hua2
+驋 bo1
+驌 su4
+驍 xiao1
+驎 lin2
+驏 chan3 zhan4
+驐 dun1
+驑 liu2
+驒 tuo2
+驓 zeng1
+驔 tan2 dian4
+驕 jiao1 xiao1 ju1 qiao2
+驖 tie3
+驗 yan4
+驘 luo2
+驙 zhan1
+驚 jing1
+驛 yi4
+驜 ye4
+驝 tuo1
+驞 bin1
+驟 zou4 zhou4
+驠 yan4
+驡 peng2
+驢 lv2
+驣 teng2
+驤 xiang1
+驥 ji4
+驦 shuang1
+驧 ju2
+驨 xi1
+驩 huan1
+驪 li2 chi2
+驫 biao1
+马 ma3
+驭 yu4
+驮 tuo2 duo4
+驯 xun2 xun4
+驰 chi2
+驱 qu1
+驲 ri4
+驳 bo2
+驴 lv2
+驵 zang3 zu3 zu4
+驶 shi3
+驷 si4
+驸 fu4
+驹 ju1
+驺 zou1 zhou4
+驻 zhu4
+驼 tuo2
+驽 nu2
+驾 jia4
+驿 yi4
+骀 tai2
+骁 xiao1
+骂 ma4
+骃 yin1
+骄 jiao1 xiao1
+骅 hua2
+骆 luo4
+骇 hai4
+骈 pian2
+骉 biao1
+骊 li2
+骋 cheng3
+验 yan4
+骍 xin1
+骎 qin1
+骏 jun4
+骐 qi2
+骑 qi2 ji4
+骒 ke4
+骓 zhui1
+骔 zong1
+骕 su4
+骖 can1
+骗 pian4
+骘 zhi4
+骙 kui2
+骚 sao1 sao3
+骛 wu4
+骜 ao2 ao4
+骝 liu2
+骞 qian1
+骟 shan4
+骠 piao4 biao1
+骡 luo2
+骢 cong1
+骣 chan3 zhan4
+骤 zou4 zhou4
+骥 ji4
+骦 shuang1
+骧 xiang1
+骨 gu3 gu1 gu2
+骩 wei3
+骪 wei3
+骫 wei3
+骬 yu2
+骭 gan4
+骮 yi4
+骯 ang1 kang3
+骰 tou2 gu3
+骱 xie4 ga4 jie4 jia2
+骲 bao1
+骳 bi4 bei4
+骴 chi1 ci1
+骵 ti3 ti1
+骶 di3
+骷 ku1
+骸 hai2 gai1
+骹 qiao1 xiao1
+骺 gou4 hou2
+骻 kua4
+骼 ge2
+骽 tui3
+骾 geng3
+骿 pian2
+髀 bi4
+髁 ke1 kua4
+髂 ka4 qia4 ge2
+髃 yu2
+髄 sui3
+髅 lou2
+髆 bo2
+髇 xiao1
+髈 pang2 bang3
+髉 bo1
+髊 ci1
+髋 kuan1
+髌 bin4
+髍 mo2
+髎 liao2
+髏 lou2
+髐 nao2 xiao1
+髑 du2
+髒 zang1 zang3
+髓 sui3
+體 ti3 ti1
+髕 bin4
+髖 kuan1
+髗 lu2
+高 gao1 gao4
+髙 gao1
+髚 qiao4
+髛 kao1
+髜 qiao1
+髝 lao4
+髞 zao4
+髟 biao1 shan1 piao4
+髠 kun1
+髡 kun1
+髢 ti4 di2 di4
+髣 fang3
+髤 xiu1
+髥 ran2
+髦 mao2 li2
+髧 dan4
+髨 kun1
+髩 bin4
+髪 fa4
+髫 tiao2
+髬 pi1
+髭 zi1
+髮 fa4 fa3
+髯 ran2
+髰 ti4
+髱 pao4
+髲 pi1 bi4
+髳 mao2
+髴 fu2 fei4
+髵 er2
+髶 rong2
+髷 qu1
+髹 xiu1
+髺 gua4 kuo4
+髻 ji4 jie2
+髼 peng2
+髽 zhua1
+髾 shao1
+髿 sha1 suo1
+鬀 ti4
+鬁 li4
+鬂 bin4
+鬃 zong1
+鬄 ti4 di2 di4
+鬅 peng2
+鬆 song1
+鬇 zheng1
+鬈 quan2
+鬉 zong1
+鬊 shun4
+鬋 jian1 jian3
+鬌 duo3
+鬍 hu2
+鬎 la4
+鬏 jiu1
+鬐 qi2
+鬑 lian2
+鬒 zhen3
+鬓 bin4
+鬔 peng2
+鬕 mo4
+鬖 san1
+鬗 man4
+鬘 man2
+鬙 seng1
+鬚 xu1
+鬛 lie4
+鬜 qian1
+鬝 qian1
+鬞 nong2
+鬟 huan2
+鬠 kuai4 kuo4
+鬡 ning2
+鬢 bin4
+鬣 lie4
+鬤 rang2
+鬥 dou4
+鬦 dou4
+鬧 nao4
+鬨 hong4 xiang4 hong1 hong3
+鬩 xi4 he4
+鬪 dou4
+鬫 han3 kan3 kan4
+鬬 dou4
+鬭 dou4
+鬮 jiu1
+鬯 chang4
+鬰 yu4
+鬱 yu4
+鬲 li4 ge2 e4
+鬳 juan4
+鬴 fu3
+鬵 qian2 xin2
+鬶 gui1
+鬷 zong1
+鬸 liu4
+鬹 gui1
+鬺 shang1
+鬻 yu4 zhou1 zhu3 zhu4 ju1
+鬼 gui3
+鬽 mei4
+鬾 ji4
+鬿 qi2
+魀 jie4
+魁 kui2 kui3 kuai4
+魂 hun2
+魃 ba2
+魄 po4 bo2 tuo4
+魅 mei4
+魆 xu4 xu1
+魇 yan3
+魈 xiao1
+魉 liang3
+魊 yu4
+魋 tui2 chui2 zhui1
+魌 qi1
+魍 wang3
+魎 liang3
+魏 wei4 wei2 wei1
+魐 jian1
+魑 chi1
+魒 piao1
+魓 bi4
+魔 mo2
+魕 ji3
+魖 xu1
+魗 chou3 chou2
+魘 yan3
+魙 zhan3 jian4
+魚 yu2
+魛 dao1
+魜 ren2
+魝 ji4
+魟 gong1 hong2
+魠 tuo2 tuo1
+魡 diao4
+魢 ji3
+魣 xu4 yu2
+魤 e2
+魥 e4
+魦 sha1
+魧 hang2
+魨 tun2
+魩 mo4
+魪 jie4
+魫 shen3
+魬 fan3 ban3
+魭 yuan2 wan3
+魮 bi2 pi2
+魯 lu3 lv3
+魰 wen2
+魱 hu2
+魲 lu2
+魳 za2
+魴 fang2
+魵 fen2
+魶 na4
+魷 you2
+魺 he2
+魻 xia2
+魼 qu1
+魽 han1
+魾 pi2 pi1
+魿 ling2
+鮀 tuo2
+鮁 bo1 ba4
+鮂 qiu2
+鮃 ping2
+鮄 fu2
+鮅 bi4
+鮆 ji4
+鮇 wei4
+鮈 ju1
+鮉 diao1
+鮊 bo2 ba4
+鮋 you2
+鮌 gun3
+鮍 pi1 pi2
+鮎 nian2
+鮏 xing1
+鮐 tai2
+鮑 bao4 bao1 pao1
+鮒 fu4
+鮓 zha3 zha4
+鮔 ju4
+鮕 gu1
+鮙 ta4
+鮚 jie2 qia4
+鮛 shu4 shu1
+鮜 hou4
+鮝 xiang3 zhen4
+鮞 er2
+鮟 an4 yan3
+鮠 wei2
+鮡 tiao1 zhao4
+鮢 zhu1
+鮣 yin4
+鮤 lie4
+鮥 luo4
+鮦 tong2 zhou4
+鮧 yi2 ti2
+鮨 qi2 yi4 zhi1
+鮩 bing4
+鮪 wei3
+鮫 jiao1 jiao3
+鮬 bu4 ku1
+鮭 gui1 wa1 xie2 kui2 hua4
+鮮 xian1 xian3 xian4
+鮯 ge2
+鮰 hui2
+鮳 kao3 kao4
+鮵 duo2
+鮶 jun1
+鮷 ti2
+鮸 mian3 man3
+鮹 xiao1
+鮺 za3
+鮻 sha1
+鮼 qin1
+鮽 yu2
+鮾 nei3
+鮿 zhe2
+鯀 gun3
+鯁 geng3
+鯃 wu2
+鯄 qiu2
+鯅 ting2 ting3 shan1
+鯆 fu3 pu1
+鯇 wan3 huan4
+鯈 tiao2 you2 chou2
+鯉 li3
+鯊 sha1
+鯋 sha1
+鯌 gao4
+鯍 meng2
+鯒 yong3
+鯓 ni2
+鯔 zi1
+鯕 qi2
+鯖 qing1 zheng1
+鯗 xiang3
+鯘 nei3
+鯙 chun2
+鯚 ji4
+鯛 diao1
+鯜 qie4
+鯝 gu4
+鯞 zhou3
+鯟 dong1
+鯠 lai2
+鯡 fei1 fei4
+鯢 ni2
+鯣 yi4
+鯤 kun1
+鯥 lu4
+鯦 jiu4
+鯧 chang1
+鯨 jing1 qing2
+鯩 lun2
+鯪 ling2
+鯫 zou1
+鯬 li2
+鯭 meng3
+鯮 zong1
+鯯 zhi4
+鯰 nian2
+鯴 shi1
+鯵 shen1
+鯶 hun3 huan4
+鯷 shi4 ti2
+鯸 hou2
+鯹 xing1 zheng1
+鯺 zhu1
+鯻 la4
+鯼 zong1
+鯽 ji4 zei2
+鯾 bian1
+鯿 bian1
+鰀 huan4
+鰁 quan2
+鰂 ze2
+鰃 wei1
+鰄 wei1
+鰅 yu2
+鰆 qun1 chun1
+鰇 rou2
+鰈 die2 qie4 zha2
+鰉 huang2
+鰊 lian4
+鰋 yan3
+鰌 qiu2 qiu1
+鰍 qiu1
+鰎 jian4
+鰏 bi4 bi1
+鰐 e4
+鰑 yang2
+鰒 fu4
+鰓 sai1 xi3
+鰔 jian3
+鰕 xia2 xia1
+鰖 tuo3 wei3
+鰗 hu2
+鰙 ruo4
+鰛 wen1
+鰜 jian1
+鰝 hao4
+鰞 wu1
+鰟 fang2 pang2
+鰠 sao1
+鰡 liu2
+鰢 ma3
+鰣 shi2
+鰤 shi1
+鰥 guan1 guan4 kun1 gun3 yin2
+鰧 teng2
+鰨 ta4 ta3 die2
+鰩 yao2
+鰪 ge2
+鰫 rong2 yong2
+鰬 qian2
+鰭 qi2
+鰮 wen1
+鰯 ruo4
+鰱 lian2
+鰲 ao2
+鰳 le4
+鰴 hui1
+鰵 min3
+鰶 ji4
+鰷 tiao2
+鰸 qu1
+鰹 jian1
+鰺 sao1 shen1 can1
+鰻 man2
+鰼 xi2
+鰽 qiu2
+鰾 biao4
+鰿 ji1 ji2
+鱀 ji4
+鱁 zhu2
+鱂 jiang1
+鱃 qiu1
+鱄 zhuan1 tuan2
+鱅 yong2 yong1
+鱆 zhang1
+鱇 kang1
+鱈 xue3
+鱉 bie1
+鱊 jue2 yu4
+鱋 qu1
+鱌 xiang4
+鱍 bo1
+鱎 jiao3
+鱏 xun2
+鱐 su4
+鱑 huang2
+鱒 zun4 zun1
+鱓 shan4 tuo2
+鱔 shan4
+鱕 fan1
+鱖 gui4 jue2
+鱗 lin2
+鱘 xun2
+鱙 miao2
+鱚 xi3
+鱝 fen4
+鱞 guan1
+鱟 hou4
+鱠 kuai4
+鱡 zei2
+鱢 sao1
+鱣 zhan1 shan4
+鱤 gan3
+鱥 gui4
+鱦 sheng2
+鱧 li3
+鱨 chang2
+鱬 ru2
+鱭 ji4
+鱮 xu4
+鱯 huo4 hu4
+鱱 li4
+鱲 lie4
+鱳 li4
+鱴 mie4
+鱵 zhen1
+鱶 xiang3
+鱷 e4
+鱸 lu2
+鱹 guan4
+鱺 li2 li3
+鱻 xian1
+鱼 yu2
+鱽 dao1
+鱾 ji3
+鱿 you2
+鲀 tun2
+鲁 lu3
+鲂 fang2
+鲃 ba1 ba4
+鲄 he2
+鲅 bo1 ba4
+鲆 ping2
+鲇 nian2
+鲈 lu2
+鲉 you2
+鲊 zha3 zha4
+鲋 fu4
+鲌 bo2 ba4
+鲍 bao4
+鲎 hou4
+鲏 pi1 pi2 ju4
+鲐 tai2
+鲑 gui1 wa1 xie2
+鲒 jie2
+鲓 kao3 kao4
+鲔 wei3
+鲕 er2
+鲖 tong2 zhou4
+鲗 ze2
+鲘 hou4
+鲙 kuai4
+鲚 ji4
+鲛 jiao3 jiao1
+鲜 xian1 xian3 xian4
+鲝 za3
+鲞 xiang3
+鲟 xun2
+鲠 geng3
+鲡 li2
+鲢 lian2
+鲣 jian1
+鲤 li3
+鲥 shi2
+鲦 tiao2
+鲧 gun3
+鲨 sha1
+鲩 wan3 huan4
+鲪 jun1
+鲫 ji4
+鲬 yong3
+鲭 qing1 zheng1
+鲮 ling2
+鲯 qi2
+鲰 zou1
+鲱 fei1
+鲲 kun1
+鲳 chang1
+鲴 gu4
+鲵 ni2
+鲶 nian2
+鲷 diao1
+鲸 jing1 qing2
+鲹 shen1
+鲺 shi1
+鲻 zi1
+鲼 fen4
+鲽 die2
+鲾 bi4 bi1
+鲿 chang2
+鳀 shi4 ti2
+鳁 wen1
+鳂 wei1
+鳃 sai1 xi3
+鳄 e4
+鳅 qiu1
+鳆 fu4
+鳇 huang2
+鳈 quan2
+鳉 jiang1
+鳊 bian1
+鳋 sao1
+鳌 ao2
+鳍 qi2
+鳎 ta4 ta3 die2
+鳏 yin2 guan1
+鳐 yao2
+鳑 fang2 pang2
+鳒 jian1
+鳓 le4
+鳔 biao4
+鳕 xue3
+鳖 bie1
+鳗 man2
+鳘 min3
+鳙 yong2 yong1
+鳚 wei4
+鳛 xi2
+鳜 jue2 gui4
+鳝 shan4
+鳞 lin2
+鳟 zun4 zun1
+鳠 huo4 hu4
+鳡 gan3
+鳢 li3
+鳣 zhan1 shan4
+鳤 guan3
+鳥 niao3 diao3 dao3 que4
+鳦 yi3 yi4
+鳧 fu2
+鳨 li4
+鳩 jiu1 qiu2 zhi4
+鳪 bu3
+鳫 yan4
+鳬 fu2
+鳭 diao1 zhao1
+鳮 ji1
+鳯 feng4
+鳱 gan1 han4
+鳲 shi1
+鳳 feng4
+鳴 ming2
+鳵 bao3
+鳶 yuan1
+鳷 zhi1
+鳸 hu4
+鳹 qin2
+鳺 fu1
+鳻 fen1
+鳼 wen2
+鳽 jian1
+鳾 shi1
+鳿 yu4
+鴀 fou3 fou2
+鴁 yao1 ao3
+鴂 jue4 jue2
+鴃 jue2
+鴄 pi1
+鴅 huan1
+鴆 zhen4
+鴇 bao3
+鴈 yan4
+鴉 ya1 ya3
+鴊 zheng4
+鴋 fang1
+鴌 feng4
+鴍 wen2
+鴎 ou1
+鴏 te4
+鴐 jia1
+鴑 nu2
+鴒 ling2
+鴓 mie4
+鴔 fu2
+鴕 tuo2
+鴖 wen2
+鴗 li4
+鴘 bian4
+鴙 zhi4
+鴚 ge1 jia1
+鴛 yuan1
+鴜 zi1
+鴝 qu2 gou1 gou4
+鴞 xiao1
+鴟 chi1 zhi1
+鴠 dan4
+鴡 ju1
+鴢 you4
+鴣 gu1
+鴤 zhong1
+鴥 yu4
+鴦 yang1
+鴧 rong4
+鴨 ya1
+鴩 tie3 hu2
+鴪 yu4
+鴬 ying1
+鴭 zhui1
+鴮 wu1
+鴯 er2
+鴰 gua1
+鴱 ai4
+鴲 zhi1
+鴳 yan4
+鴴 heng2 hang2
+鴵 jiao1
+鴶 ji2
+鴷 lie4
+鴸 zhu1
+鴹 ren2
+鴺 yi2
+鴻 hong2 hong4
+鴼 luo4
+鴽 ru2
+鴾 mou2
+鴿 ge1
+鵀 ren4 ren2
+鵁 jiao1
+鵂 xiu1
+鵃 zhou1 zhao1
+鵄 zhi1 chi1
+鵅 luo4
+鵉 luan2
+鵊 jia2
+鵋 ji4
+鵌 yu2 tu2
+鵍 huan1
+鵎 tuo3
+鵏 bu1 bu3
+鵐 wu2
+鵑 juan1
+鵒 yu4
+鵓 bo2
+鵔 xun4 jun4
+鵕 xun4
+鵖 bi4 bi1
+鵗 xi1
+鵘 jun4
+鵙 ju2
+鵚 tu2
+鵛 jing1
+鵜 ti2 ti1
+鵝 e2
+鵞 e2
+鵟 kuang2
+鵠 hu2 gu3 he4
+鵡 wu3
+鵢 shen1
+鵣 lai4 chi4
+鵦 lu4
+鵧 ping2 bing4
+鵨 shu1
+鵩 fu2
+鵪 an1 yan4 ya1
+鵫 zhao4
+鵬 peng2 feng4
+鵭 qin2
+鵮 qian1
+鵯 bei1
+鵰 diao1
+鵱 lu4
+鵲 que4
+鵳 jian1
+鵴 ju2
+鵵 tu4
+鵶 ya1
+鵷 yuan1
+鵸 qi2
+鵹 li2
+鵺 ye4
+鵻 zhui1
+鵼 kong1
+鵽 zhui4 duo4 zhua1
+鵾 kun1
+鵿 sheng1
+鶀 qi2
+鶁 jing1
+鶂 yi4
+鶃 yi4
+鶄 jing1
+鶅 zi1
+鶆 lai2
+鶇 dong1
+鶈 qi1
+鶉 chun2 tuan2
+鶊 geng1
+鶋 ju1
+鶌 qu1 ju1
+鶏 ji1
+鶐 shu4
+鶒 chi4
+鶓 miao2
+鶔 rou2
+鶕 an1 ya1
+鶖 qiu1
+鶗 ti2
+鶘 hu2
+鶙 ti2
+鶚 e4
+鶛 jie1
+鶜 mao2
+鶝 fu2
+鶞 chun1
+鶟 tu2
+鶠 yan3
+鶡 he2 jie4
+鶢 yuan2
+鶣 pian1
+鶤 yun4 kun1
+鶥 mei2
+鶦 hu2
+鶧 ying1
+鶨 dun4
+鶩 wu4 mu4
+鶪 ju2
+鶬 cang1 qiang1
+鶭 fang3
+鶮 gu4
+鶯 ying1
+鶰 yuan2
+鶱 xuan1 xian1
+鶲 weng1
+鶳 shi1
+鶴 he4
+鶵 chu2
+鶶 tang2
+鶷 xia4
+鶸 ruo4
+鶹 liu2
+鶺 ji2
+鶻 gu2 hu2 gu3
+鶼 jian1 qian1
+鶽 zhun3 sun3
+鶾 han4
+鶿 zi1 ci2
+鷀 zi1 ci2
+鷁 ni4 yi4
+鷂 yao4 yao2
+鷃 yan4
+鷄 ji1
+鷅 li4
+鷆 tian2 zhen1
+鷇 kou4 gou4
+鷈 ti1
+鷉 ti1
+鷊 ni4 yi4
+鷋 tu2
+鷌 ma3
+鷍 jiao1
+鷎 gao1
+鷏 tian2 zhen1
+鷐 chen2
+鷑 li4
+鷒 zhuan1
+鷓 zhe4
+鷔 ao2
+鷕 yao3 wei3
+鷖 yi1
+鷗 ou1
+鷘 chi4
+鷙 zhi4 zhe2
+鷚 liao2 liu4
+鷛 rong2 yong2
+鷜 lou2
+鷝 bi4
+鷞 shuang1
+鷟 zhuo2
+鷠 yu2
+鷡 wu2
+鷢 jue2
+鷣 yin2
+鷤 quan2 ti2
+鷥 si1
+鷦 jiao1
+鷧 yi4
+鷨 hua1
+鷩 bi4 bie1 chang3
+鷪 ying1
+鷫 su4
+鷬 huang2
+鷭 fan2
+鷮 jiao1
+鷯 liao2
+鷰 yan4 yan1
+鷱 kao1
+鷲 jiu4
+鷳 xian2
+鷴 xian2
+鷵 tu2
+鷶 mai3
+鷷 zun1
+鷸 yu4 shu4
+鷹 ying1
+鷺 lu4
+鷻 tuan2
+鷼 xian2
+鷽 xue2
+鷾 yi4
+鷿 pi4
+鸀 shu2 shu3 zhu2 zhuo2
+鸁 luo2
+鸂 qi1 xi1
+鸃 yi2
+鸄 ji2
+鸅 zhe2
+鸆 yu2
+鸇 zhan1
+鸈 ye4
+鸉 yang2
+鸊 pi4 bi4
+鸋 ning2
+鸌 huo4 hu4
+鸍 mi2
+鸎 ying1
+鸏 meng2
+鸐 di2
+鸑 yue4
+鸒 yu2 yu4
+鸓 lei3
+鸔 bao4
+鸕 lu2
+鸖 he4
+鸗 long2
+鸘 shuang1
+鸙 yue4
+鸚 ying1
+鸛 guan4 huan1 quan2
+鸜 qu2
+鸝 li2
+鸞 luan2
+鸟 niao3 diao3
+鸠 jiu1
+鸡 ji1
+鸢 yuan1
+鸣 ming2
+鸤 shi1
+鸥 ou1
+鸦 ya1
+鸧 cang1 qiang1
+鸨 bao3
+鸩 zhen4
+鸪 gu1
+鸫 dong1
+鸬 lu2
+鸭 ya1
+鸮 xiao1
+鸯 yang1
+鸰 ling2
+鸱 zhi1
+鸲 qu2
+鸳 yuan1
+鸴 xue2
+鸵 tuo2
+鸶 si1
+鸷 zhi4
+鸸 er2
+鸹 gua1
+鸺 xiu1
+鸻 heng2 hang2
+鸼 zhou1 zhao1
+鸽 ge1
+鸾 luan2
+鸿 hong2
+鹀 wu2
+鹁 bo2
+鹂 li2
+鹃 juan1
+鹄 hu2 gu3
+鹅 e2
+鹆 yu4
+鹇 xian2
+鹈 ti2
+鹉 wu3
+鹊 que4
+鹋 miao2
+鹌 an1 yan4
+鹍 kun1
+鹎 bei1
+鹏 peng2
+鹐 qian1
+鹑 chun2 tuan2
+鹒 geng1
+鹓 yuan1
+鹔 su4
+鹕 hu2
+鹖 he2 jie4
+鹗 e4
+鹘 gu2 hu2
+鹙 qiu1
+鹚 zi1 ci2
+鹛 mei2
+鹜 mu4
+鹝 ni4 yi4
+鹞 yao4 yao2
+鹟 weng1
+鹠 liu2
+鹡 ji2
+鹢 ni4 yi4
+鹣 jian1
+鹤 he4
+鹥 yi1
+鹦 ying1
+鹧 zhe4
+鹨 liao2
+鹩 liao2
+鹪 jiao1
+鹫 jiu4
+鹬 yu4
+鹭 lu4
+鹮 xuan2
+鹯 zhan1
+鹰 ying1
+鹱 huo4 hu4
+鹲 meng2
+鹳 guan4
+鹴 shuang1
+鹵 lu3
+鹶 jin1
+鹷 ling2
+鹸 jian3
+鹹 xian2
+鹺 cuo2
+鹻 jian3
+鹼 jian3
+鹽 yan2 yan4
+鹾 cuo2
+鹿 lu4 lv2
+麀 you1
+麁 cu1
+麂 ji3
+麃 biao1 pao2 piao3
+麄 cu1
+麅 biao1 pao2
+麆 zhu4 chu2
+麇 jun1 kun3 qun2
+麈 zhu3
+麉 jian1
+麊 mi2
+麋 mi2
+麌 wu2 yu3
+麍 liu2
+麎 chen2
+麏 jun1
+麐 lin2
+麑 ni2 mi2
+麒 qi2
+麓 lu4
+麔 jiu4
+麕 jun1 qun2
+麖 jing1
+麗 li4 li2
+麘 xiang1
+麙 yan2
+麚 jia1
+麛 mi2
+麜 li4
+麝 she4
+麞 zhang1
+麟 lin2
+麠 jing1
+麡 ji1
+麢 ling2
+麣 yan2
+麤 cu1
+麥 mai4
+麦 mai4
+麧 ge1 he2
+麨 chao3
+麩 fu1
+麪 mian3 mian4
+麫 mian3 mian4
+麬 fu1
+麭 pao4
+麮 qu4
+麯 qu2 qu1
+麰 mou2
+麱 fu1
+麲 xian4
+麳 lai2
+麴 qu2 qu1
+麵 mian4
+麷 feng1
+麸 fu1
+麹 qu2
+麺 mian4
+麻 ma2 ma1
+麼 me5 mo5 mo3 ma5
+麽 mo5 mo3 ma5 me5
+麾 hui1
+黀 zou1
+黁 nen1 nun2
+黂 fen2
+黃 huang2
+黄 huang2
+黅 jin1
+黆 guang1
+黇 tian1
+黈 tou3
+黉 heng2 hong2
+黊 xi1
+黋 kuang3 kuang4
+黌 heng2 hong2
+黍 shu3
+黎 li2
+黏 nian2 nian1 zhan1
+黐 chi1 li2
+黑 hei1 he4
+黒 hei1
+黓 yi4
+黔 qian2
+黕 dan1 dan3
+黖 xi4
+黗 tuan3
+默 mo4
+黙 mo4
+黚 qian2
+黛 dai4
+黜 chu4
+黝 you3 yi1
+點 dian3 zhan1 duo4
+黟 yi1
+黠 xia2
+黡 yan3
+黢 qu1 qu4
+黣 mei3
+黤 yan3
+黥 qing2 jing1
+黦 yu4 yue4
+黧 li2 lai2
+黨 dang3 zhang3
+黩 du2
+黪 can3
+黫 yin1 yan1
+黬 an4
+黭 yan1 yan3
+黮 tan3 dan3 shen4 dan4
+黯 an4 an1
+黰 zhen3
+黱 dai4
+黲 can3
+黳 yi1
+黴 mei2
+黵 dan3
+黶 yan3
+黷 du2
+黸 lu2
+黹 zhi3 xian4
+黺 fen3
+黻 fu2 fu4
+黼 fu3
+黽 min3 meng2 meng3 mian3
+黾 min3 meng2 meng3 mian3
+黿 yuan2
+鼀 cu4
+鼁 qu4
+鼂 chao2 zhao1
+鼃 wa1
+鼄 zhu1
+鼅 zhi1
+鼆 mang2 meng3
+鼇 ao2
+鼈 bie1
+鼉 tuo2
+鼊 bi4
+鼋 yuan2
+鼌 chao2 zhao1
+鼍 tuo2
+鼎 ding3 zhen1
+鼏 mi4
+鼐 nai4
+鼑 ding3 zhen1
+鼒 zi1
+鼓 gu3
+鼔 gu3
+鼕 dong1 tong2
+鼖 fen2
+鼗 tao2
+鼘 yuan1
+鼙 pi2
+鼚 chang1
+鼛 gao1
+鼜 qi4
+鼝 yuan1
+鼞 tang1
+鼟 teng1
+鼠 shu3
+鼡 shu3
+鼢 fen2
+鼣 fei4
+鼤 wen2
+鼥 ba2
+鼦 diao1
+鼧 tuo2
+鼨 tong2 zhong1
+鼩 qu2
+鼪 sheng1
+鼫 shi2
+鼬 you4
+鼭 shi2
+鼮 ting2
+鼯 wu2
+鼰 nian4
+鼱 jing1
+鼲 hun2
+鼳 ju2
+鼴 yan3
+鼵 tu2 tu1
+鼶 ti2 si1
+鼷 xi1 xi2
+鼸 xian3
+鼹 yan3
+鼺 lei2
+鼻 bi2
+鼼 yao3
+鼽 qiu2
+鼾 han1
+鼿 wu1
+齀 wu4
+齁 hou1 hou2
+齂 xi4
+齃 ge2 e4
+齄 zha1
+齅 xiu4
+齆 weng4
+齇 zha1
+齈 nong2
+齉 nang4
+齊 qi2 ji1 ji4 jian3 zhai1 zi1
+齋 zhai1
+齌 ji4 qi1
+齍 zi1
+齎 ji1 qi2
+齏 ji1
+齐 qi2 ji1 ji4 jian3 zhai1 zi1
+齑 ji1
+齒 chi3
+齓 chen4
+齔 chen4
+齕 he2
+齖 ya2
+齗 ken3 yin2
+齘 xie4
+齙 pao2
+齚 cuo4 ze2
+齛 shi4
+齜 zi1 chai2
+齝 chi1
+齞 nian4 yan4
+齟 ju3 zha1
+齠 tiao2
+齡 ling2
+齢 ling2
+齣 chu1
+齤 quan2
+齥 xie4
+齦 ken3 yin2 qian3
+齧 nie4
+齨 jiu4
+齩 yao3 jiao1 yao1
+齪 chuo4
+齫 kun3
+齬 yu3 wu2
+齭 chu3
+齮 yi3
+齯 ni2
+齰 cuo4 ze2
+齱 zou1 chuo4
+齲 qu3
+齳 nen3 kun3 yun3
+齴 xian3 yan3
+齵 ou2 yu2
+齶 e4
+齷 wo4
+齸 yi4
+齹 chuo1
+齺 zou1
+齻 dian1
+齼 chu3
+齽 jin4
+齾 ya4
+齿 chi3
+龀 chen4
+龁 he2
+龂 ken3 yin2
+龃 ju3
+龄 ling2
+龅 bao1
+龆 tiao2
+龇 zi1
+龈 yin2 ken3
+龉 yu3
+龊 chuo4
+龋 qu3
+龌 wo4
+龍 long2 long3 mang2
+龎 pang2
+龏 gong1
+龐 pang2
+龑 yan3
+龒 long2
+龓 long2
+龔 gong1
+龕 kan1 ke4
+龖 ta4
+龗 ling2
+龘 ta4
+龙 long2 long3 mang2
+龚 gong1
+龛 kan1
+龜 gui1 jun1 qiu1
+龝 qiu1
+龞 bie1
+龟 gui1 jun1 qiu1
+龠 yue4
+龡 chui4
+龢 he2 he4 huo4
+龣 jue2
+龤 xie2
+龥 yu4
+鿃 shan3
+癩 la4
+兀 wu4
+嗀 huo4
+塚 zhong3
+晴 qing2
+凞 xi1
+猪 zhu1
+益 yi4
+礼 li3
+神 shen2
+祥 xiang2
+福 fu2
+靖 jing4
+精 jing1
+羽 yu3
+諸 zhu1
+逸 yi4
+都 du1 dou1
+飯 fan4
+飼 si4
+館 guan3
+鶴 he4
+𠂔 zi3
+𠂢 pai4
+𠂤 dui1
+𠔉 juan4
+𠖥 chong3
+𠜎 xian4
+𠭴 zhuo1
+𠲿 shu4
+𠼻 ji1
+𡀔 lu4
+𡗗 peng3
+𡿺 nao3
+𢦏 zai1
+𢭆 chou1
+𢲷 sou1
+𢶣 die2
+𣎴 dun3
+𤇾 ying4
+𤍤 zhang1
+𤏲 zhou4
+𥜥 yi4
+𦄂 dai4
+𦤎 gao1
+𦥯 xue2
+𧵳 she2
+𧼮 tang1
+𩜇 juan3

--- a/lib/chinese_pinyin.rb
+++ b/lib/chinese_pinyin.rb
@@ -6,13 +6,19 @@ require 'chinese_pinyin/version'
 class Pinyin
   class <<self
     attr_accessor :table
+    attr_accessor :ruby2
 
     def init_table
       return if @table
-      @table = {}
-      open(File.dirname(__FILE__) + '/../data/Mandarin.dat') do |file|
+
+      # Ruby 2.0以后默认即为UTF-8编码，使用新的码表以提升效率
+      @ruby2  = !!(RUBY_VERSION =~ /^2/)
+      datfile = @ruby2 ? 'pinyin-utf8.dat' : 'Mandarin.dat'
+      @table  = {}
+
+      File.open(File.dirname(__FILE__) + "/../data/#{datfile}") do |file|
         while line = file.gets
-          key, value = line.split(' ', 2)
+          key, value  = line.split(' ', 2)
           @table[key] = value
         end
       end
@@ -20,11 +26,13 @@ class Pinyin
 
     def init_word_table
       return if @words_table
+
       @words_table = {}
+
       if ENV["WORDS_FILE"]
-        open(ENV["WORDS_FILE"]) do |file|
+        File.open(ENV["WORDS_FILE"]) do |file|
           while line = file.gets
-            key, value = line.sub("\n", "").split('|', 2)
+            key, value        = line.sub("\n", "").split('|', 2)
             @words_table[key] = value
           end
         end
@@ -32,24 +40,41 @@ class Pinyin
     end
 
     def translate(chars, options={})
-      splitter = options[:splitter] || ' '
-      tone = options[:tone] || false
+      splitter = options.fetch(:splitter, ' ')
+      tone     = options.fetch(:tone, false)
+      camel    = options.fetch(:camelcase, false)
 
       init_word_table
-      return @words_table[chars].gsub(' ', splitter) if @words_table[chars]
+      results = @words_table[chars]
+      if results
+        results = results.split
+        results.map!(&:downcase)
+        results.map!(&:capitalize) if camel
+        results.map! { |x| (48..57).include?(x[-1].ord) ? x.chop! : x } unless tone
+
+        return results.join(splitter)
+      end
 
       init_table
-      results = []
+      results    = []
       is_english = false
+
       chars.scan(/./).each do |char|
-        key = sprintf("%X", char.unpack("U").first)
+        key = @ruby2 ? char : sprintf("%X", char.unpack("U").first)
+
         if @table[key]
           results << splitter if is_english
-          pinyin = @table[key].chomp.split(' ', 2)[0].downcase
+
+          is_english = false
+          pinyin     = @table[key].chomp.split(' ', 2)[0]
+
+          pinyin.downcase! unless @ruby2
           pinyin.chop! unless tone
+          pinyin.capitalize! if camel
+
           results << pinyin
           results << splitter
-          is_english = false
+
         else
           results << char
           is_english = true

--- a/test/Words.dat
+++ b/test/Words.dat
@@ -1,1 +1,2 @@
 广州|guang zhou
+上海|ShANg4 hAi3

--- a/test/chinese_pinyin_test.rb
+++ b/test/chinese_pinyin_test.rb
@@ -7,16 +7,31 @@ class PinyinTest < Test::Unit::TestCase
   def test_t
     assert_equal("zhong guo", Pinyin.t('中国'))
     assert_equal("zhong guo english ri", Pinyin.t('中国english日'))
+    assert_equal("shang hai very good o ye", Pinyin.t('上海very good哦耶'))
   end
 
   def test_t_with_splitter
     assert_equal("zhong-guo", Pinyin.t('中国', splitter: '-'))
     assert_equal("huangzhimin", Pinyin.t('黄志敏', splitter: ''))
     assert_equal("guang-zhou", Pinyin.t('广州', splitter: '-'))
+    assert_equal("shang-hai", Pinyin.t('上海', splitter: '-'))
   end
 
   def test_t_with_tone
     assert_equal("zhong1 guo2", Pinyin.t('中国', tone: true))
     assert_equal("huang2 zhi4 min3", Pinyin.t('黄志敏', tone: true))
+    assert_equal("shang4 hai3", Pinyin.t('上海', tone: true))
+  end
+
+  def test_t_with_camelcase
+    assert_equal("Zhong Guo", Pinyin.t('中国', camelcase: true))
+    assert_equal("Huang Zhi Min", Pinyin.t('黄志敏', camelcase: true))
+    assert_equal("Zhong1 Guo2", Pinyin.t('中国', camelcase: true, tone: true))
+    assert_equal("Huang2 Zhi4 Min3", Pinyin.t('黄志敏', camelcase: true, tone: true))
+    assert_equal("Zhong-Guo", Pinyin.t('中国', camelcase: true, splitter: '-'))
+    assert_equal("HuangZhiMin", Pinyin.t('黄志敏', camelcase: true, splitter: ''))
+    assert_equal("Guang-Zhou", Pinyin.t('广州', camelcase: true, splitter: '-'))
+    assert_equal("Shang-Hai", Pinyin.t('上海', camelcase: true, splitter: '-'))
+    assert_equal("Shang4-Hai3", Pinyin.t('上海', camelcase: true, tone:true, splitter: '-'))
   end
 end


### PR DESCRIPTION
- 添加了新的纯UTF-8码表，对Ruby 2.0做了优化，这样就不用每次都unpack一下了，并且码表里就已经是小写的拼音，也不用每次都downcase一下了
- 完善了对Words.dat的支持，现在在Words.dat里自定义的拼音也可以写音调数字了，并且大小写乱点也不要紧
- 新增了camelcase选项，在人名转换场景下比较有用，比如：

``` ruby
Pinyin.t("洪亮", camelcase: true) # 输出Hong Liang
```

而且可以跟splitter和tone联动

``` ruby
Pinyin.t("洪亮", camelcase: true, splitter: '_', tone: true) # 输出Hong2_Liang4
```

嘿嘿～
