### PR TITLE
增加自定义的拼音特性

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Usage
     Pinyin.t('中国', splitter: '') => "zhongguo"
     Pinyin.t('中国', tone: true) => "zhong1 guo2"
     Pinyin.t('中国', tonemarks: true) => "zhōng guó"
+    Pinyin.t('北京') { |letters, i| letters[0].upcase } => 'BJ'
+    Pinyin.t('北京') { |letters, i| letters[0].upcase if i == 0 } => 'B'
 
 Polyphone Issue
 ---------------

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Usage
     Pinyin.t('中国', splitter: '') => "zhongguo"
     Pinyin.t('中国', tone: true) => "zhong1 guo2"
     Pinyin.t('中国', tonemarks: true) => "zhōng guó"
-    Pinyin.t('北京') { |letters, i| letters[0].upcase } => 'BJ'
+    Pinyin.t('北京') { |letters| letters[0].upcase } => 'BJ'
     Pinyin.t('北京') { |letters, i| letters[0].upcase if i == 0 } => 'B'
 
 Polyphone Issue

--- a/lib/chinese_pinyin.rb
+++ b/lib/chinese_pinyin.rb
@@ -89,9 +89,12 @@ class Pinyin
               break if pinyin.tr! v, TONE_MARK[v.to_sym][tone_index]
             }
           end
-
-          results << pinyin
-          results << splitter
+          if block_given?
+            results << (yield pinyin, results.size)
+          else
+            results << pinyin
+            results << splitter
+          end
         else
           if char =~ /[a-zA-Z0-9]/
             results << char

--- a/test/chinese_pinyin_test.rb
+++ b/test/chinese_pinyin_test.rb
@@ -43,4 +43,9 @@ class PinyinTest < Test::Unit::TestCase
     assert_equal('zhōng guó', Pinyin.t('中国', tonemarks: true))
     assert_equal('běi jīng', Pinyin.t('北京', tonemarks: true))
   end
+
+  def test_t_with_custom
+    assert_equal('BJ', Pinyin.t('北京') { |letters, i| letters[0].upcase } )
+    assert_equal('B', Pinyin.t('北京') { |letters, i| letters[0].upcase if i == 0 } )
+  end
 end

--- a/test/chinese_pinyin_test.rb
+++ b/test/chinese_pinyin_test.rb
@@ -45,7 +45,7 @@ class PinyinTest < Test::Unit::TestCase
   end
 
   def test_t_with_custom
-    assert_equal('BJ', Pinyin.t('北京') { |letters, i| letters[0].upcase } )
+    assert_equal('BJ', Pinyin.t('北京') { |letters| letters[0].upcase } )
     assert_equal('B', Pinyin.t('北京') { |letters, i| letters[0].upcase if i == 0 } )
   end
 end


### PR DESCRIPTION
需要一些新特性（源自 #16 ），
如用拼音的缩写标识，
或者用拼音首字母来分组，用户按照拼音首字母选择，以更进一步优化体验。
这些特性很多，很复杂，和业务相关。所以采用策略模式，直接提供自定义的编程接口。

'''ruby
Pinyin.t('北京') { |letters, i| letters[0].upcase } => 'BJ'
Pinyin.t('北京') { |letters, i| letters[0].upcase if i == 0 } => 'B'
'''