### PR TITLE
Force utf-8 encoding on datfile read

### DIFF
--- a/lib/chinese_pinyin.rb
+++ b/lib/chinese_pinyin.rb
@@ -50,6 +50,7 @@ class Pinyin
     end
 
     def translate(chars, options={})
+      chars     = chars.force_encoding("UTF-8")
       splitter  = options.fetch(:splitter, ' ')
       tonemarks = options.fetch(:tonemarks, false)
       tone      = options.fetch(:tone, false || tonemarks)

--- a/lib/chinese_pinyin.rb
+++ b/lib/chinese_pinyin.rb
@@ -26,7 +26,7 @@ class Pinyin
       datfile = @ruby2 ? 'pinyin-utf8.dat' : 'Mandarin.dat'
       @table  = {}
 
-      File.open(File.dirname(__FILE__) + "/../data/#{datfile}") do |file|
+      File.open(File.dirname(__FILE__) + "/../data/#{datfile}", "r:UTF-8",) do |file|
         while line = file.gets
           key, value  = line.split(' ', 2)
           @table[key] = value


### PR DESCRIPTION
I was having an issue where in some instances the dat file data was being read in as ASCII, and the match in the table wasn't working (if @table[key]).

I initally posted a SO question. This explains the problem a bit more. 

http://stackoverflow.com/questions/38182635/ruby-library-returns-nothing-when-called-from-inside-vim-filter

My first attempt at solution was to force utf8 on my vim script that wraps your library (below) but that didn't work. 

```

#!/usr/bin/env ruby
require 'chinese_pinyin'

STDIN.each_line do |line|
  line = line.force_encoding("UTF-8")
  puts Pinyin.t(line, tonemarks: true)
end

```
This surprised me and led me to find that the data file was strangely being read in as ASCII when the input pipe characters are ASCII.

I made an SO question about vim encodings this but also little response. 

http://stackoverflow.com/questions/38203617/what-in-vim-determines-encoding-of-text-sent-external-apps-through-a-filter

Even stranger is that when I open MacVim from clicking on the icon, it sends input pipe encoding of ASCII, but when I start it from the command line, the input pipe encoding is utf-8, even though in both cases the fileencoding=utf-8.

Anyway long story short. Since encoding into the script may be variable and unpredictable, maybe it's a good idea to force utf8 inside your library?

That's what these simple changes do. Use if you like.